### PR TITLE
Updated ls-label command to list all available checklists and workflo…

### DIFF
--- a/bug/bug.go
+++ b/bug/bug.go
@@ -666,7 +666,7 @@ func (bug *Bug) Compile() Snapshot {
 		id:     bug.id,
 		Status: ProposedStatus,
 	}
-	snap.Checklists = make(map[string]map[entity.Id]ChecklistSnapshot)
+	snap.Checklists = make(map[Label]map[entity.Id]ChecklistSnapshot)
 	snap.Reviews = make(map[string]ReviewInfo)
 
 	it := NewOperationIterator(bug)

--- a/bug/checklists.go
+++ b/bug/checklists.go
@@ -31,7 +31,7 @@ type ChecklistSection struct {
 	Questions []ChecklistQuestion
 }
 type Checklist struct {
-	Label    string
+	Label    Label
 	Title    string
 	Sections []ChecklistSection
 }
@@ -40,7 +40,7 @@ type ChecklistSnapshot struct {
 	LastEdit time.Time
 }
 
-var checklistStore map[string]Checklist
+var checklistStore map[Label]Checklist
 var repo repository.ClockedRepo
 
 // initChecklistStore attempts to read the checklists configuration out of the
@@ -61,7 +61,7 @@ func initChecklistStore() error {
 		return fmt.Errorf("unable to read checklists config: %q", err)
 	}
 
-	checklistStoreTemp := make(map[string]Checklist)
+	checklistStoreTemp := make(map[Label]Checklist)
 
 	err = json.Unmarshal(checklistData, &checklistStoreTemp)
 	if err != nil {
@@ -74,7 +74,7 @@ func initChecklistStore() error {
 }
 
 // GetChecklist returns a Checklist template out of the store
-func GetChecklist(label string) (Checklist, error) {
+func GetChecklist(label Label) (Checklist, error) {
 	if checklistStore == nil {
 		if err := initChecklistStore(); err != nil {
 			return Checklist{}, err
@@ -88,6 +88,21 @@ func GetChecklist(label string) (Checklist, error) {
 	}
 
 	return cl, nil
+}
+
+// GetChecklistLabels returns a slice of all the available checklist labels
+func GetChecklistLabels() []Label {
+	if checklistStore == nil {
+		if err := initChecklistStore(); err != nil {
+			return nil
+		}
+	}
+
+	var labels []Label
+	for _, cl := range checklistStore {
+		labels = append(labels, cl.Label)
+	}
+	return labels
 }
 
 func (s ChecklistState) String() string {

--- a/bug/label.go
+++ b/bug/label.go
@@ -91,3 +91,11 @@ func (l Label) Validate() error {
 
 	return nil
 }
+
+func (l Label) IsChecklist() bool {
+	return strings.HasPrefix(string(l), "checklist:")
+}
+
+func (l Label) IsWorkflow() bool {
+	return strings.HasPrefix(string(l), "workflow:")
+}

--- a/bug/op_label_change.go
+++ b/bug/op_label_change.go
@@ -180,7 +180,7 @@ func ChangeLabels(b Interface, author identity.Interface, unixTime int64, add, r
 
 		// if it's a workflow, check it exists
 		if strings.HasPrefix(str, "workflow:") {
-			if newWorkflow = FindWorkflow(str); newWorkflow == nil {
+			if newWorkflow = FindWorkflow(Label(str)); newWorkflow == nil {
 				results = append(results, LabelChangeResult{Label: label, Status: LabelChangeInvalidWorkflow})
 				continue
 			}

--- a/bug/op_label_change.go
+++ b/bug/op_label_change.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -179,14 +178,14 @@ func ChangeLabels(b Interface, author identity.Interface, unixTime int64, add, r
 		}
 
 		// if it's a workflow, check it exists
-		if strings.HasPrefix(str, "workflow:") {
+		if label.IsWorkflow() {
 			if newWorkflow = FindWorkflow(Label(str)); newWorkflow == nil {
 				results = append(results, LabelChangeResult{Label: label, Status: LabelChangeInvalidWorkflow})
 				continue
 			}
 			// if so, remove any existing workflows
 			for _, lbl := range snap.Labels {
-				if strings.HasPrefix(string(lbl), "workflow:") {
+				if lbl.IsWorkflow() {
 					remove = append(remove, string(lbl))
 				}
 			}
@@ -212,7 +211,7 @@ func ChangeLabels(b Interface, author identity.Interface, unixTime int64, add, r
 		}
 
 		// unless this is a workflow change, don't allow workflow labels to be removed
-		if newWorkflow == nil && strings.HasPrefix(str, "workflow:") {
+		if newWorkflow == nil && label.IsWorkflow() {
 			results = append(results, LabelChangeResult{Label: label, Status: LabelChangeInvalidWorkflow})
 			continue
 		}

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -2,7 +2,6 @@ package bug
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/daedaleanai/git-ticket/entity"
@@ -151,7 +150,7 @@ func (snap *Snapshot) GetUserChecklists(reviewer entity.Id) (map[Label]Checklist
 
 	// Only checklists named in the labels list are currently valid
 	for _, l := range snap.Labels {
-		if strings.HasPrefix(string(l), "checklist:") {
+		if l.IsChecklist() {
 			if snapshotChecklist, present := snap.Checklists[l][reviewer]; present {
 				checklists[l] = snapshotChecklist.Checklist
 			} else {
@@ -172,7 +171,7 @@ func (snap *Snapshot) GetChecklistCompoundStates() map[Label]ChecklistState {
 
 	// Only checklists named in the labels list are currently valid
 	for _, l := range snap.Labels {
-		if strings.HasPrefix(string(l), "checklist:") {
+		if l.IsChecklist() {
 			// default state is Pending
 			states[l] = Pending
 
@@ -201,7 +200,7 @@ func (snap *Snapshot) GetChecklistCompoundStates() map[Label]ChecklistState {
 // NextStates returns a slice of next possible states for the assigned workflow
 func (snap *Snapshot) NextStates() ([]Status, error) {
 	for _, l := range snap.Labels {
-		if strings.HasPrefix(string(l), "workflow:") {
+		if l.IsWorkflow() {
 			w := FindWorkflow(l)
 			if w == nil {
 				return nil, fmt.Errorf("invalid workflow %s", l)
@@ -216,7 +215,7 @@ func (snap *Snapshot) NextStates() ([]Status, error) {
 // destination from the current state for the assigned workflow
 func (snap *Snapshot) ValidateTransition(newStatus Status) error {
 	for _, l := range snap.Labels {
-		if strings.HasPrefix(string(l), "workflow:") {
+		if l.IsWorkflow() {
 			w := FindWorkflow(l)
 			if w == nil {
 				return fmt.Errorf("invalid workflow %s", l)

--- a/bug/snapshot_test.go
+++ b/bug/snapshot_test.go
@@ -13,7 +13,7 @@ func TestSnapshot_GetChecklistCompoundStates(t *testing.T) {
 	// Create an initial snapshot, one checklist reviewed by two people, all passed.
 	snapshot := Snapshot{
 		Labels: []Label{"checklist:XYZ"},
-		Checklists: map[string]map[entity.Id]ChecklistSnapshot{
+		Checklists: map[Label]map[entity.Id]ChecklistSnapshot{
 			"checklist:XYZ": map[entity.Id]ChecklistSnapshot{
 				"123": ChecklistSnapshot{
 					Checklist: Checklist{
@@ -57,21 +57,21 @@ func TestSnapshot_GetChecklistCompoundStates(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[string]ChecklistState{"checklist:XYZ": Passed})
+	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Passed})
 
 	// one review has left an answer pending, should still be overall pass
 	snapshot.Checklists["checklist:XYZ"]["456"].Checklist.Sections[0].Questions[1].State = Pending
-	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[string]ChecklistState{"checklist:XYZ": Passed})
+	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Passed})
 
 	// both reviewers have left an answer pending, should be overall pending
 	snapshot.Checklists["checklist:XYZ"]["123"].Checklist.Sections[1].Questions[1].State = Pending
-	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[string]ChecklistState{"checklist:XYZ": Pending})
+	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Pending})
 
 	// one review has left an answer failed, should be overall fail
 	snapshot.Checklists["checklist:XYZ"]["456"].Checklist.Sections[0].Questions[1].State = Failed
-	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[string]ChecklistState{"checklist:XYZ": Failed})
+	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Failed})
 
 	// the default state for an unreviewed checklist is pending
 	snapshot.Labels = append(snapshot.Labels, "checklist:ABC")
-	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[string]ChecklistState{"checklist:XYZ": Failed, "checklist:ABC": Pending})
+	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Failed, "checklist:ABC": Pending})
 }

--- a/bug/workflow.go
+++ b/bug/workflow.go
@@ -14,7 +14,7 @@ type Transition struct {
 }
 
 type Workflow struct {
-	label        string
+	label        Label
 	initialState Status
 	transitions  []Transition
 }
@@ -22,13 +22,22 @@ type Workflow struct {
 var workflowStore []Workflow
 
 // FindWorkflow searches the workflow store by name and returns a pointer to it
-func FindWorkflow(name string) *Workflow {
+func FindWorkflow(name Label) *Workflow {
 	for wf := range workflowStore {
 		if workflowStore[wf].label == name {
 			return &workflowStore[wf]
 		}
 	}
 	return nil
+}
+
+// GetWorkflowLabels returns a slice of all the available workflow labels
+func GetWorkflowLabels() []Label {
+	var labels []Label
+	for _, wf := range workflowStore {
+		labels = append(labels, wf.label)
+	}
+	return labels
 }
 
 // NextStates returns a slice of next possible states in the workflow

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -600,17 +600,29 @@ func (c *RepoCache) AllBugsIds() []entity.Id {
 //
 // Note: in the future, a proper label policy could be implemented where valid
 // labels are defined in a configuration file. Until that, the default behavior
-// is to return the list of labels already used.
+// is to return the list of labels already used, plus all defined checklists and
+// workflows.
 func (c *RepoCache) ValidLabels() []bug.Label {
 	c.muBug.RLock()
 	defer c.muBug.RUnlock()
 
 	set := map[bug.Label]interface{}{}
 
+	// all currently used labels
 	for _, excerpt := range c.bugExcerpts {
 		for _, l := range excerpt.Labels {
 			set[l] = nil
 		}
+	}
+
+	// all available workflow labels
+	for _, wf := range bug.GetWorkflowLabels() {
+		set[wf] = nil
+	}
+
+	// all available checklist labels
+	for _, cl := range bug.GetChecklistLabels() {
+		set[cl] = nil
 	}
 
 	result := make([]bug.Label, len(set))

--- a/commands/review_checklist.go
+++ b/commands/review_checklist.go
@@ -6,6 +6,7 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 
+	"github.com/daedaleanai/git-ticket/bug"
 	"github.com/daedaleanai/git-ticket/cache"
 	"github.com/daedaleanai/git-ticket/commands/select"
 	"github.com/daedaleanai/git-ticket/input"
@@ -44,7 +45,7 @@ func runReviewChecklist(cmd *cobra.Command, args []string) error {
 	ticketChecklistLabels := make([]string, 0, len(ticketChecklists))
 
 	for k := range ticketChecklists {
-		ticketChecklistLabels = append(ticketChecklistLabels, k)
+		ticketChecklistLabels = append(ticketChecklistLabels, string(k))
 	}
 
 	// If there are multiple checklists associated with the ticket then give the
@@ -69,13 +70,13 @@ func runReviewChecklist(cmd *cobra.Command, args []string) error {
 
 	// Use the editor to edit the checklist, if it changed then create an update
 	// operation and commit
-	clChange, err := input.ChecklistEditorInput(repo, ticketChecklists[selectedChecklistLabel])
+	clChange, err := input.ChecklistEditorInput(repo, ticketChecklists[bug.Label(selectedChecklistLabel)])
 	if err != nil {
 		return err
 	}
 
 	if clChange {
-		_, err = b.SetChecklist(ticketChecklists[selectedChecklistLabel])
+		_, err = b.SetChecklist(ticketChecklists[bug.Label(selectedChecklistLabel)])
 		if err != nil {
 			return err
 		}

--- a/commands/show.go
+++ b/commands/show.go
@@ -48,9 +48,9 @@ func runShowBug(cmd *cobra.Command, args []string) error {
 	var workflow string = "<NONE ASSIGNED>"
 
 	for _, lbl := range snapshot.Labels {
-		if strings.HasPrefix(lbl.String(), "workflow:") {
+		if lbl.IsWorkflow() {
 			workflow = strings.TrimPrefix(lbl.String(), "workflow:")
-		} else if strings.HasPrefix(lbl.String(), "checklist:") {
+		} else if lbl.IsChecklist() {
 			continue
 		} else {
 			labels = append(labels, lbl.String())

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -665,7 +665,7 @@ func (sb *showBug) review(g *gocui.Gui, v *gocui.View) error {
 	ticketChecklistLabels := make([]string, 0, len(ticketChecklists))
 
 	for k := range ticketChecklists {
-		ticketChecklistLabels = append(ticketChecklistLabels, k)
+		ticketChecklistLabels = append(ticketChecklistLabels, string(k))
 	}
 
 	// If there are multiple checklists associated with the ticket then give the
@@ -678,7 +678,7 @@ func (sb *showBug) review(g *gocui.Gui, v *gocui.View) error {
 		go func() {
 			selectedChecklistLabel := <-c
 
-			checklist, ok := ticketChecklists[selectedChecklistLabel]
+			checklist, ok := ticketChecklists[bug.Label(selectedChecklistLabel)]
 
 			if !ok {
 				ui.msgPopup.Activate(msgPopupErrorTitle, "Invalid checklist "+selectedChecklistLabel)
@@ -696,7 +696,7 @@ func (sb *showBug) review(g *gocui.Gui, v *gocui.View) error {
 	}
 
 	// Just the one checklist, so edit that
-	return reviewWithEditor(sb.bug, ticketChecklists[ticketChecklistLabels[0]])
+	return reviewWithEditor(sb.bug, ticketChecklists[bug.Label(ticketChecklistLabels[0])])
 }
 
 func (sb *showBug) setTitle(g *gocui.Gui, v *gocui.View) error {


### PR DESCRIPTION
…ws as well as currently used labels. Updated underlying type of checklist and workflow to use Label type instead of string.


hidden amongst the type change, the interesting stuff is in:
cache/repo_cache.go
bug/checklists.go
bug/workflow.go