### PR TITLE
Improved mechanism for completing checklists: states can be entered i…

### DIFF
--- a/bug/checklists_test.go
+++ b/bug/checklists_test.go
@@ -31,8 +31,8 @@ func TestChecklists_ChecklistCompoundState(t *testing.T) {
 	testChecklist.Sections[0].Questions[0].State = NotApplicable
 	assert.Equal(t, testChecklist.CompoundState(), Passed)
 
-	testChecklist.Sections[0].Questions[1].State = Pending
-	assert.Equal(t, testChecklist.CompoundState(), Pending)
+	testChecklist.Sections[0].Questions[1].State = TBD
+	assert.Equal(t, testChecklist.CompoundState(), TBD)
 
 	testChecklist.Sections[0].Questions[2].State = Failed
 	assert.Equal(t, testChecklist.CompoundState(), Failed)

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -172,8 +172,8 @@ func (snap *Snapshot) GetChecklistCompoundStates() map[Label]ChecklistState {
 	// Only checklists named in the labels list are currently valid
 	for _, l := range snap.Labels {
 		if l.IsChecklist() {
-			// default state is Pending
-			states[l] = Pending
+			// default state is TBD
+			states[l] = TBD
 
 			clMap, present := snap.Checklists[l]
 			if present {

--- a/bug/snapshot_test.go
+++ b/bug/snapshot_test.go
@@ -59,19 +59,19 @@ func TestSnapshot_GetChecklistCompoundStates(t *testing.T) {
 
 	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Passed})
 
-	// one review has left an answer pending, should still be overall pass
-	snapshot.Checklists["checklist:XYZ"]["456"].Checklist.Sections[0].Questions[1].State = Pending
+	// one review has left an answer TBD, should still be overall pass
+	snapshot.Checklists["checklist:XYZ"]["456"].Checklist.Sections[0].Questions[1].State = TBD
 	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Passed})
 
-	// both reviewers have left an answer pending, should be overall pending
-	snapshot.Checklists["checklist:XYZ"]["123"].Checklist.Sections[1].Questions[1].State = Pending
-	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Pending})
+	// both reviewers have left an answer TBD, should be overall TBD
+	snapshot.Checklists["checklist:XYZ"]["123"].Checklist.Sections[1].Questions[1].State = TBD
+	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": TBD})
 
 	// one review has left an answer failed, should be overall fail
 	snapshot.Checklists["checklist:XYZ"]["456"].Checklist.Sections[0].Questions[1].State = Failed
 	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Failed})
 
-	// the default state for an unreviewed checklist is pending
+	// the default state for an unreviewed checklist is TBD
 	snapshot.Labels = append(snapshot.Labels, "checklist:ABC")
-	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Failed, "checklist:ABC": Pending})
+	assert.Equal(t, snapshot.GetChecklistCompoundStates(), map[Label]ChecklistState{"checklist:XYZ": Failed, "checklist:ABC": TBD})
 }


### PR DESCRIPTION
…n shorter form and any errors in parsing the completed checklist will leave the user with a backup file so nothing is lost

Note: I also changed the "Pending" state to "TBD" because it was easier to abbreviate without causing confusion with "Passed"