### PR TITLE
Self-validate of commit containing key, when no keys in repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,6 @@ matrix:
     go: 1.13.x
   - language: go
     go: 1.14.x
-  - language: node_js
-    node_js: node
-    before_install:
-      - cd webui
-    after_success: []
-  - language: node_js
-    node_js: lts/*
-    before_install:
-      - cd webui
-    after_success: []
 
 env:
   GO111MODULE=on
@@ -30,14 +20,3 @@ before_install:
 after_success:
   - if [ ! -z "$TRAVIS_TAG" ]; then make releases; fi
 
-deploy:
-  provider: releases
-  skip_cleanup: true
-  api_key:
-    secure: fLW37YkuY7KhVGpS6kgAAZPxgnePkLJG6AhWArOdVjgF0LMpps3PdvmfLkt+UUwjN0B+7l5NZSNU6c7F7R9AtJG5sfI7glFYxhQj3SdDr3rJCM1jqiJoCpkMGNHaJXsuGN1T/fWyfhHkhhyucbPv0d16llOsw98h7dIR1tCEFqMbfyA2G0182uKlOgZ/cjQGTRvU2hFgRpVHWCPcZkG+d0anLyCHtECXAwVQO5cijwNa4a7BEvIIYKRK6/j/GTrn9SqTisww3n1wxaItmEL91HbR6oqKrU9lUCJ6dTI/3JszKfLxrxGSSmwgtxa2tccV8AfmiqMXk4dISsHWwMthFzCp+I0htbdm5d1hbx9Jfq+5zJjV5Vka5ewfpWwSMOKkZpsEspjSy7iQPLk8IvkDq8t7NQ8kU2j5Z//nEEFa1Rym+sWsKhzas6fs09hv5V9p5iCU0bCnrncavhD6u1NN6FaYlZtBz8a0p2SyOrgW2Yglg37IKsZPW805e+6L7L515+jQ5OkdbrGsHr9ko3YG0OX1UkMfJ7ntQXfNeADHP90TmML8t7t+O8pNFFRiQUDPO0rbytXwneQoE/Jhdmj10Rhqi/OEm5A5uV5smItc7eg2OE6lBWYOeIQyGpQrh6eTx9cO+osX0o5ROMr4IVhJ0e/rRuR+PCm/2f8JUzHAfsk=
-  file_glob: true
-  file: dist/**/*
-  on:
-    repo: daedaleanai/git-ticket
-    go: 1.13.x
-    tags: true

--- a/commands/user_key_add.go
+++ b/commands/user_key_add.go
@@ -44,7 +44,6 @@ func newUserKeyAddCommand() *cobra.Command {
 	return cmd
 }
 
-
 func runUserKeyAdd(env *Env, opts userKeyAddOptions, args []string) error {
 	id, args, err := ResolveUser(env.backend, args)
 	if err != nil {
@@ -78,7 +77,7 @@ func runUserKeyAdd(env *Env, opts userKeyAddOptions, args []string) error {
 		return err
 	}
 
-	validator, err := validate.NewValidator(env.backend)
+	validator, err := validate.NewValidator(env.repo, env.backend)
 	if err != nil {
 		return errors.Wrap(err, "failed to create validator")
 	}
@@ -94,5 +93,3 @@ func runUserKeyAdd(env *Env, opts userKeyAddOptions, args []string) error {
 
 	return id.Commit()
 }
-
-

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -31,6 +31,7 @@ func runValidate(env *Env, args []string) error {
 		return err
 	}
 
+	// If there is no FirstKey it means the repository has no Identities.
 	if validator.FirstKey != nil {
 		fmt.Printf("first commit signed with key: %s\n", validator.FirstKey.Fingerprint())
 	}

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -42,15 +42,6 @@ func runValidate(env *Env, args []string) error {
 			return err
 		}
 
-		if validator.FirstKey == nil {
-			// if our validator contains no key, check if this commit contains an identity with a key
-			// so we can validate our self
-			err = validator.CheckCommitForKey(hash)
-			if err != nil {
-				return err
-			}
-		}
-
 		_, err = validator.ValidateCommit(hash)
 		if err != nil {
 			if refErr == nil {

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/MichaelMure/go-term-text v0.2.9 h1:jUxInT3rDhl4WoJgLnmMS3hR79zigyJS1T
 github.com/MichaelMure/go-term-text v0.2.9/go.mod h1:2QSU/Nn2u41Tqoar+90RlYuhjngJPYgod7evnsYwkWc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -34,7 +35,9 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/corpix/uarand v0.1.1 h1:RMr1TWc9F4n5jiPDzFHtmaUXLKLNUFK0SgCLo4BhX/U=
 github.com/corpix/uarand v0.1.1/go.mod h1:SFKZvkcRoLqVRFZ4u25xPmp6m9ktANfbpXZ7SJ0/FNU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -60,6 +63,7 @@ github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.0.0 h1:7NQHvd9FVid8VL4qVUMm8XifBK+2xCoZ2lSk0agRrHM=
 github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-git-fixtures/v4 v4.0.1 h1:q+IFMfLx200Q3scvt2hN79JsEzy4AmBTp/pqnefH+Bc=
 github.com/go-git/go-git-fixtures/v4 v4.0.1/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
 github.com/go-git/go-git/v5 v5.0.0 h1:k5RWPm4iJwYtfWoxIJy4wJX9ON7ihPeZZYC1fLYDnpg=
 github.com/go-git/go-git/v5 v5.0.0/go.mod h1:oYD8y9kWsGINPFJoLdaScGCN6dlKg23blmClfZwtUVA=
@@ -89,6 +93,7 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428 h1:Mo9W14pwbO9VfRe+ygqZ8dFbPpoIK1HFrG/zjTuQ+nc=
 github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428/go.mod h1:uhpZMVGznybq1itEKXj6RYw9I71qK4kH+OGMjRC4KEo=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -111,6 +116,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
@@ -137,6 +143,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -159,10 +166,12 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -257,6 +266,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -136,7 +136,7 @@ func ReadRemote(repo repository.ClockedRepo, remote string, id string) (*Identit
 	return read(repo, ref)
 }
 
-// ReadCommit loads identity data from a single commit in git
+// ReadCommit loads an identity data from a single commit in git
 func ReadCommit(repo repository.Repo, hash repository.Hash) (*Identity, error) {
 	return read(repo, hash.String())
 }

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -132,8 +132,13 @@ func ReadLocal(repo repository.ClockedRepo, id entity.Id) (*Identity, error) {
 
 // ReadRemote load a remote Identity from the identities data available in git
 func ReadRemote(repo repository.ClockedRepo, remote string, id string) (*Identity, error) {
-       ref := fmt.Sprintf(identityRemoteRefPattern, remote) + id
-       return read(repo, ref)
+	ref := fmt.Sprintf(identityRemoteRefPattern, remote) + id
+	return read(repo, ref)
+}
+
+// ReadCommit loads identity data from a single commit in git
+func ReadCommit(repo repository.Repo, hash repository.Hash) (*Identity, error) {
+	return read(repo, hash.String())
 }
 
 // read will load and parse an identity from git
@@ -320,7 +325,7 @@ func RemoveKeyMutator(fingerprint string, removedKey **Key) func(mutator Mutator
 				if removedKey != nil {
 					*removedKey = key
 				}
-				keys := make([]*Key, len(mutator.Keys) - 1)
+				keys := make([]*Key, len(mutator.Keys)-1)
 				copy(keys, mutator.Keys[0:j])
 				copy(keys[j:], mutator.Keys[j+1:])
 				mutator.Keys = keys

--- a/tests/read_bugs_test.go
+++ b/tests/read_bugs_test.go
@@ -28,6 +28,8 @@ func benchmarkReadBugs(bugNumber int, t *testing.B) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(repo)
 
+	repository.SetupSigningKey(t, repo, "a@e.org")
+
 	random_bugs.FillRepoWithSeed(repo, bugNumber, 42)
 	t.ResetTimer()
 

--- a/validate/validator.go
+++ b/validate/validator.go
@@ -264,10 +264,6 @@ func (v *Validator) checkCommitForKey(hash repository.Hash) error {
 // ValidateCommit checks the commit signature along with the key's expire time.
 // Returns the pubkey used to sign the specified commit, or an error.
 func (v *Validator) ValidateCommit(hash repository.Hash) (*packet.PublicKey, error) {
-	if v.checkedCommits[hash] {
-		return nil, nil
-	}
-
 	commit, err := v.backend.ResolveCommit(hash)
 	if err != nil {
 		return nil, err
@@ -288,7 +284,6 @@ func (v *Validator) ValidateCommit(hash repository.Hash) (*packet.PublicKey, err
 		return nil, errors.Wrap(err, "invalid signature")
 	}
 
-	v.checkedCommits[hash] = true
 	return signingKey, nil
 }
 

--- a/validate/validator.go
+++ b/validate/validator.go
@@ -240,7 +240,7 @@ func (v *Validator) updateKeyring(info *versionInfo) {
 
 // checkCommitForKey looks to see if the commit contains a git ticket identity update including key, if it does
 // then add the key to the keyring
-func (v *Validator) CheckCommitForKey(hash repository.Hash) error {
+func (v *Validator) checkCommitForKey(hash repository.Hash) error {
 	identity, err := identity.ReadCommit(v.repo, hash)
 	if err != nil {
 		return err
@@ -297,6 +297,15 @@ func (v *Validator) ValidateCommit(hash repository.Hash) (*packet.PublicKey, err
 
 	for _, h := range commit.ParentHashes {
 		_, err = v.ValidateCommit(repository.Hash(h.String()))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if v.FirstKey == nil {
+		// if our validator contains no key, check if this commit contains an identity with a key
+		// so we can validate our self
+		err = v.checkCommitForKey(hash)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This pull request fixes an issue where the very first identity (containing a key) is pushed to a repository. It cannot be verified remotely (using the pre-receive / update hooks) because the identities refs don't yet exist, so git ticket cannot read the key in when validating.

The fix is to add a condition in commands/validate.go to check if FirstKey is not set when iterating through the commits, if not then the commit itself is first checked for a key before validating it. To support this CheckCommitForKey was added to validate/validator.go which does as it describes and adds the key to the keyring if successful. To support this the validator needs to know the repo info when initialised, plus a ReadCommit function was needed in identity/identity.go to attempt to parse a single commit.