### PR TITLE
fixed pre and post run for the review clear command to ensure the bac…

### DIFF
--- a/commands/review_clear.go
+++ b/commands/review_clear.go
@@ -12,9 +12,10 @@ func newReviewClearCommand() *cobra.Command {
 	env := newEnv()
 
 	cmd := &cobra.Command{
-		Use:     "clear <DiffID> [<id>]",
-		Short:   "Clear the Differential Revision data associated with a ticket.",
-		PreRunE: loadRepoEnsureUser(env),
+		Use:      "clear <DiffID> [<id>]",
+		Short:    "Clear the Differential Revision data associated with a ticket.",
+		PreRunE:  loadBackendEnsureUser(env),
+		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runReviewClear(env, args)
 		},


### PR DESCRIPTION
…kend is loaded

The backend is needed in order to read the bug info from the repo. Command crashes without this change when repo is selected.