### PR TITLE
extended ccb function to allow members to be assigned per status

### DIFF
--- a/bug/ccb.go
+++ b/bug/ccb.go
@@ -26,8 +26,9 @@ const (
 // CcbInfo is stored in a ticket history every time a user is added or removed,
 // or has approved or blocked the ticket
 type CcbInfo struct {
-	User  identity.Interface
-	State CcbState
+	User   identity.Interface
+	Status Status
+	State  CcbState
 }
 
 // Stringify function for CcbState

--- a/bug/ccb.go
+++ b/bug/ccb.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CcbState represents the status of a CCB group member with respect to a ticket
+// CcbState represents the state of an approver with respect to a ticket status
 type CcbState int
 
 const (
@@ -23,12 +23,12 @@ const (
 	RemovedCcbState           // removed from the ticket
 )
 
-// CcbInfo is stored in a ticket history every time a user is added or removed,
+// CcbInfo is stored in a ticket history every time an approver is added or removed,
 // or has approved or blocked the ticket
 type CcbInfo struct {
-	User   identity.Interface
-	Status Status
-	State  CcbState
+	User   identity.Interface // The approver
+	Status Status             // The ticket status (e.g. vetted) that the approver is associated with
+	State  CcbState           // The state of the approval
 }
 
 // Stringify function for CcbState

--- a/bug/op_set_ccb.go
+++ b/bug/op_set_ccb.go
@@ -160,9 +160,9 @@ func (s SetCcbTimelineItem) String() string {
 	var output strings.Builder
 	switch s.Ccb.State {
 	case AddedCcbState:
-		output.WriteString("added \"" + s.Ccb.User.DisplayName() + "\" to CCB status " + s.Ccb.Status.String())
+		output.WriteString("added \"" + s.Ccb.User.DisplayName() + "\" as CCB approver for status " + s.Ccb.Status.String())
 	case RemovedCcbState:
-		output.WriteString("removed \"" + s.Ccb.User.DisplayName() + "\" from CCB status " + s.Ccb.Status.String())
+		output.WriteString("removed \"" + s.Ccb.User.DisplayName() + "\" as CCB approver for status " + s.Ccb.Status.String())
 	case ApprovedCcbState:
 		output.WriteString("approved ticket status " + s.Ccb.Status.String())
 	case BlockedCcbState:

--- a/bug/op_set_ccb_test.go
+++ b/bug/op_set_ccb_test.go
@@ -13,7 +13,7 @@ func TestSetCcbSerialize(t *testing.T) {
 	var rene = identity.NewBare("René Descartes", "rene@descartes.fr")
 	var mickey = identity.NewBare("Mickey Mouse", "mm@disney.com")
 	unix := time.Now().Unix()
-	before := NewSetCcbOp(rene, unix, mickey, AddedCcbState)
+	before := NewSetCcbOp(rene, unix, mickey, VettedStatus, ApprovedCcbState)
 
 	data, err := json.Marshal(before)
 	assert.NoError(t, err)

--- a/bug/op_set_status.go
+++ b/bug/op_set_status.go
@@ -150,7 +150,7 @@ func SetStatus(b Interface, author identity.Interface, unixTime int64, status St
 	if err := snap.ValidateTransition(status); err != nil {
 		return nil, err
 	}
-	if err := snap.CheckCcbApproved(); err != nil {
+	if err := snap.CheckCcbApproved(status); err != nil {
 		return nil, err
 	}
 	b.Append(op)

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -134,25 +134,25 @@ func (snap *Snapshot) HasAnyActor(ids ...entity.Id) bool {
 }
 
 // GetCcbState returns the state assocated with the id in the ticket CCB group
-func (snap *Snapshot) GetCcbState(id entity.Id) CcbState {
+func (snap *Snapshot) GetCcbState(id entity.Id, status Status) CcbState {
 	for _, c := range snap.Ccb {
-		if c.User.Id() == id {
+		if c.User.Id() == id && c.Status == status {
 			return c.State
 		}
 	}
 	return RemovedCcbState
 }
 
-// CheckCcbApproved returns an error if the CCB group is not large enough or not all have approved the ticket
-func (snap *Snapshot) CheckCcbApproved() error {
-	if len(snap.Ccb) < 2 {
-		return fmt.Errorf("ticket has insufficient CCB group (min: 2)")
-	}
+// CheckCcbApproved returns an error if not all the CCB group for the given status have approved the ticket
+func (snap *Snapshot) CheckCcbApproved(status Status) error {
 	for _, c := range snap.Ccb {
-		if c.State != ApprovedCcbState {
-			return fmt.Errorf("not all CCB group have approved ticket")
+		if c.Status == status {
+			if c.State != ApprovedCcbState {
+				return fmt.Errorf("not all CCB group have approved ticket status %s", status)
+			}
 		}
 	}
+
 	return nil
 }
 

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -148,7 +148,7 @@ func (snap *Snapshot) CheckCcbApproved(status Status) error {
 	for _, c := range snap.Ccb {
 		if c.Status == status {
 			if c.State != ApprovedCcbState {
-				return fmt.Errorf("not all CCB group have approved ticket status %s", status)
+				return fmt.Errorf("not all CCB approvers have approved ticket status %s", status)
 			}
 		}
 	}
@@ -213,15 +213,15 @@ func (snap *Snapshot) GetChecklistCompoundStates() map[Label]ChecklistState {
 	return states
 }
 
-// NextStates returns a slice of next possible states for the assigned workflow
-func (snap *Snapshot) NextStates() ([]Status, error) {
+// NextStatuses returns a slice of next possible statuses for the assigned workflow
+func (snap *Snapshot) NextStatuses() ([]Status, error) {
 	for _, l := range snap.Labels {
 		if l.IsWorkflow() {
 			w := FindWorkflow(l)
 			if w == nil {
 				return nil, fmt.Errorf("invalid workflow %s", l)
 			}
-			return w.NextStates(snap.Status)
+			return w.NextStatuses(snap.Status)
 		}
 	}
 	return nil, fmt.Errorf("ticket has no associated workflow")

--- a/bug/workflow.go
+++ b/bug/workflow.go
@@ -66,7 +66,10 @@ func (w *Workflow) ValidateTransition(from, to Status) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid transition %s -> %s", from, to)
+
+	// invalid transition, return error with list of valid transitions
+	nextStates, _ := w.NextStates(from)
+	return fmt.Errorf("invalid transition %s->%s, possible next states: %s", from, to, nextStates)
 }
 
 func init() {

--- a/bug/workflow.go
+++ b/bug/workflow.go
@@ -40,16 +40,16 @@ func GetWorkflowLabels() []Label {
 	return labels
 }
 
-// NextStates returns a slice of next possible states in the workflow
+// NextStatuses returns a slice of next possible statuses in the workflow
 // for the given one
-func (w *Workflow) NextStates(s Status) ([]Status, error) {
-	var validStates []Status
+func (w *Workflow) NextStatuses(s Status) ([]Status, error) {
+	var validStatuses []Status
 	for _, t := range w.transitions {
 		if t.start == s {
-			validStates = append(validStates, t.end)
+			validStatuses = append(validStatuses, t.end)
 		}
 	}
-	return validStates, nil
+	return validStatuses, nil
 }
 
 // ValidateTransition checks if the transition is valid for a given start and end
@@ -68,8 +68,8 @@ func (w *Workflow) ValidateTransition(from, to Status) error {
 	}
 
 	// invalid transition, return error with list of valid transitions
-	nextStates, _ := w.NextStates(from)
-	return fmt.Errorf("invalid transition %s->%s, possible next states: %s", from, to, nextStates)
+	nextStatuses, _ := w.NextStatuses(from)
+	return fmt.Errorf("invalid transition %s->%s, possible next statuses: %s", from, to, nextStatuses)
 }
 
 func init() {

--- a/bug/workflow_test.go
+++ b/bug/workflow_test.go
@@ -36,9 +36,9 @@ func TestWorkflow_FindWorkflow(t *testing.T) {
 	}
 }
 
-func TestWorkflow_NextStates(t *testing.T) {
-	// The valid next states for each status in the testWorkflow
-	var nextStates = [][]Status{
+func TestWorkflow_NextStatuses(t *testing.T) {
+	// The valid next statuses for each status in the testWorkflow
+	var nextStatuses = [][]Status{
 		nil,                                // first status is 1
 		{VettedStatus},                     // from ProposedStatus
 		{ProposedStatus, InProgressStatus}, // from VettedStatus
@@ -50,12 +50,12 @@ func TestWorkflow_NextStates(t *testing.T) {
 		nil,                                // from DoneStatus
 	}
 
-	for currentState := FirstStatus; currentState <= LastStatus; currentState++ {
-		next, err := testWorkflow.NextStates(currentState)
+	for currentStatus := FirstStatus; currentStatus <= LastStatus; currentStatus++ {
+		next, err := testWorkflow.NextStatuses(currentStatus)
 		if err != nil {
-			t.Fatal("Invalid next states", currentState, ">", next, "(error", err, ")")
+			t.Fatal("Invalid next statuses", currentStatus, ">", next, "(error", err, ")")
 		}
-		assert.Equal(t, nextStates[currentState], next)
+		assert.Equal(t, nextStatuses[currentStatus], next)
 	}
 }
 

--- a/cache/bug_cache.go
+++ b/cache/bug_cache.go
@@ -416,44 +416,44 @@ func (c *BugCache) SetMetadataRaw(author *IdentityCache, unixTime int64, target 
 	return op, c.notifyUpdated()
 }
 
-func (c *BugCache) CcbAdd(user *IdentityCache) (*bug.SetCcbOperation, error) {
+func (c *BugCache) CcbAdd(user *IdentityCache, status bug.Status) (*bug.SetCcbOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
 	}
 
-	return c.SetCcbRaw(author, time.Now().Unix(), nil, user, bug.AddedCcbState)
+	return c.SetCcbRaw(author, time.Now().Unix(), nil, user, status, bug.AddedCcbState)
 }
 
-func (c *BugCache) CcbApprove() (*bug.SetCcbOperation, error) {
+func (c *BugCache) CcbApprove(status bug.Status) (*bug.SetCcbOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
 	}
 
-	return c.SetCcbRaw(author, time.Now().Unix(), nil, author, bug.ApprovedCcbState)
+	return c.SetCcbRaw(author, time.Now().Unix(), nil, author, status, bug.ApprovedCcbState)
 }
 
-func (c *BugCache) CcbBlock() (*bug.SetCcbOperation, error) {
+func (c *BugCache) CcbBlock(status bug.Status) (*bug.SetCcbOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
 	}
 
-	return c.SetCcbRaw(author, time.Now().Unix(), nil, author, bug.BlockedCcbState)
+	return c.SetCcbRaw(author, time.Now().Unix(), nil, author, status, bug.BlockedCcbState)
 }
 
-func (c *BugCache) CcbRm(user *IdentityCache) (*bug.SetCcbOperation, error) {
+func (c *BugCache) CcbRm(user *IdentityCache, status bug.Status) (*bug.SetCcbOperation, error) {
 	author, err := c.repoCache.GetUserIdentity()
 	if err != nil {
 		return nil, err
 	}
 
-	return c.SetCcbRaw(author, time.Now().Unix(), nil, user, bug.RemovedCcbState)
+	return c.SetCcbRaw(author, time.Now().Unix(), nil, user, status, bug.RemovedCcbState)
 }
 
-func (c *BugCache) SetCcbRaw(author *IdentityCache, unixTime int64, metadata map[string]string, user *IdentityCache, state bug.CcbState) (*bug.SetCcbOperation, error) {
-	op, err := bug.SetCcb(c.bug, author.Identity, unixTime, user.Identity, state)
+func (c *BugCache) SetCcbRaw(author *IdentityCache, unixTime int64, metadata map[string]string, user *IdentityCache, status bug.Status, state bug.CcbState) (*bug.SetCcbOperation, error) {
+	op, err := bug.SetCcb(c.bug, author.Identity, unixTime, user.Identity, status, state)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/ccb.go
+++ b/commands/ccb.go
@@ -10,8 +10,7 @@ func newCcbCommand() *cobra.Command {
 		Short: "Change Control Board (CCB) actions of a ticket.",
 		Long: `Change Control Board (CCB) allows the transition of tickets through the workflow to be monitored.
 
-CCB members, as defined in the "ccb" config, can be added to the status of a ticket, meaning they must approve the ticket before it can be moved to that status.
-A ticket can only be approved if it is currently in the preceding status.
+CCB members, as defined in the "ccb" config, can be added as approvers to the status of a ticket, meaning they must approve the ticket before it can be moved to that status.
 `,
 	}
 

--- a/commands/ccb.go
+++ b/commands/ccb.go
@@ -8,6 +8,11 @@ func newCcbCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ccb",
 		Short: "Change Control Board (CCB) actions of a ticket.",
+		Long: `Change Control Board (CCB) allows the transition of tickets through the workflow to be monitored.
+
+CCB members, as defined in the "ccb" config, can be added to the status of a ticket, meaning they must approve the ticket before it can be moved to that status.
+A ticket can only be approved if it is currently in the preceding status.
+`,
 	}
 
 	cmd.AddCommand(newCcbAddCommand())

--- a/commands/ccb_add.go
+++ b/commands/ccb_add.go
@@ -15,8 +15,8 @@ func newCcbAddCommand() *cobra.Command {
 	env := newEnv()
 
 	cmd := &cobra.Command{
-		Use:      "add <user> [<id>]",
-		Short:    "Add the CCB member to a ticket.",
+		Use:      "add <user> <status> [<id>]",
+		Short:    "Add a CCB member to a ticket status.",
 		PreRunE:  loadBackendEnsureUser(env),
 		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -28,12 +28,18 @@ func newCcbAddCommand() *cobra.Command {
 }
 
 func runCcbAdd(env *Env, args []string) error {
-	if len(args) < 1 {
-		return errors.New("no user supplied")
+	if len(args) < 2 {
+		return errors.New("no user and/or status supplied")
 	}
 
 	userToAddString := args[0]
-	args = args[1:]
+
+	status, err := bug.StatusFromString(args[1])
+	if err != nil {
+		return err
+	}
+
+	args = args[2:]
 
 	b, args, err := _select.ResolveBug(env.backend, args)
 	if err != nil {
@@ -43,7 +49,7 @@ func runCcbAdd(env *Env, args []string) error {
 	// Perform some checks before adding the user to the CCB of the ticket:
 	//   is the current user a CCB member?
 	//   is the user to add a CCB member?
-	//   is the user to add already in the CCB group of the ticket?
+	//   is the user to add already in the CCB group of the ticket status?
 
 	currentUserIdentity, err := env.backend.GetUserIdentity()
 
@@ -92,19 +98,19 @@ func runCcbAdd(env *Env, args []string) error {
 		return errors.New(userToAddIdentity.DisplayName() + " is not a CCB member")
 	}
 
-	if b.Snapshot().GetCcbState(userToAddId) != bug.RemovedCcbState {
-		fmt.Printf("%s is already in the ticket CCB group\n", userToAddIdentity.DisplayName())
+	if b.Snapshot().GetCcbState(userToAddId, status) != bug.RemovedCcbState {
+		fmt.Printf("%s is already in the ticket %s CCB group\n", userToAddIdentity.DisplayName(), status)
 		return nil
 	}
 
 	// Everything looks ok, add the user
 
-	_, err = b.CcbAdd(userToAddIdentity)
+	_, err = b.CcbAdd(userToAddIdentity, status)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Adding %s to CCB group of ticket %s\n", userToAddIdentity.DisplayName(), b.Id().Human())
+	fmt.Printf("Adding %s to %s CCB group of ticket %s\n", userToAddIdentity.DisplayName(), status, b.Id().Human())
 
 	return b.Commit()
 }

--- a/commands/ccb_add.go
+++ b/commands/ccb_add.go
@@ -16,7 +16,7 @@ func newCcbAddCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:      "add <user> <status> [<id>]",
-		Short:    "Add a CCB member to a ticket status.",
+		Short:    "Add a CCB member as an approver of a ticket status.",
 		PreRunE:  loadBackendEnsureUser(env),
 		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -46,10 +46,10 @@ func runCcbAdd(env *Env, args []string) error {
 		return err
 	}
 
-	// Perform some checks before adding the user to the CCB of the ticket:
+	// Perform some checks before adding the user as an approver of the ticket status:
 	//   is the current user a CCB member?
 	//   is the user to add a CCB member?
-	//   is the user to add already in the CCB group of the ticket status?
+	//   is the user to add already an approver of the ticket status?
 
 	currentUserIdentity, err := env.backend.GetUserIdentity()
 
@@ -99,7 +99,7 @@ func runCcbAdd(env *Env, args []string) error {
 	}
 
 	if b.Snapshot().GetCcbState(userToAddId, status) != bug.RemovedCcbState {
-		fmt.Printf("%s is already in the ticket %s CCB group\n", userToAddIdentity.DisplayName(), status)
+		fmt.Printf("%s is already an approver of the ticket status %s\n", userToAddIdentity.DisplayName(), status)
 		return nil
 	}
 
@@ -110,7 +110,7 @@ func runCcbAdd(env *Env, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Adding %s to %s CCB group of ticket %s\n", userToAddIdentity.DisplayName(), status, b.Id().Human())
+	fmt.Printf("Adding %s as an approver of the ticket %s status %s\n", userToAddIdentity.DisplayName(), b.Id().Human(), status)
 
 	return b.Commit()
 }

--- a/commands/ccb_approve.go
+++ b/commands/ccb_approve.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/daedaleanai/git-ticket/bug"
@@ -33,26 +32,33 @@ func runCcbApprove(env *Env, args []string) error {
 	}
 
 	// Perform some checks before approving the CCB of the ticket:
-	//   is the current user in the CCB group of the ticket?
+	//   is the current user in the CCB group of the ticket status?
 	//   has the current user already approved the ticket?
 
 	currentUserIdentity, err := env.backend.GetUserIdentity()
 
-	currentUserState := b.Snapshot().GetCcbState(currentUserIdentity.Id())
-
-	if currentUserState == bug.RemovedCcbState {
-		return errors.New("you are not in the ticket CCB group")
-	}
-	if currentUserState == bug.ApprovedCcbState {
-		fmt.Println("you have already approved this ticket")
-		return nil
-	}
-
-	// Everything looks ok, approve
-
-	_, err = b.CcbApprove()
+	nextStates, err := b.Snapshot().NextStates()
 	if err != nil {
 		return err
+	}
+
+	for _, s := range nextStates {
+		currentUserState := b.Snapshot().GetCcbState(currentUserIdentity.Id(), s)
+
+		if currentUserState == bug.RemovedCcbState {
+			return fmt.Errorf("you are not in the ticket %s CCB group", s)
+		}
+		if currentUserState == bug.ApprovedCcbState {
+			fmt.Println("you have already approved this ticket")
+			return nil
+		}
+
+		// Everything looks ok, approve
+
+		_, err = b.CcbApprove(s)
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Printf("Approving ticket %s\n", b.Id().Human())

--- a/commands/ccb_block.go
+++ b/commands/ccb_block.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/daedaleanai/git-ticket/bug"
@@ -12,8 +13,8 @@ func newCcbBlockCommand() *cobra.Command {
 	env := newEnv()
 
 	cmd := &cobra.Command{
-		Use:      "block [<id>]",
-		Short:    "Block a ticket.",
+		Use:      "block <status> [<id>]",
+		Short:    "Block a ticket status.",
 		PreRunE:  loadBackendEnsureUser(env),
 		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -25,40 +26,46 @@ func newCcbBlockCommand() *cobra.Command {
 }
 
 func runCcbBlock(env *Env, args []string) error {
+	if len(args) < 1 {
+		return errors.New("no status supplied")
+	}
+
+	status, err := bug.StatusFromString(args[0])
+	if err != nil {
+		return err
+	}
+
+	args = args[1:]
 
 	b, args, err := _select.ResolveBug(env.backend, args)
 	if err != nil {
 		return err
 	}
 
-	// Perform some checks before blocking the CCB of the ticket:
-	//   is the current user in the CCB group of the ticket status?
+	// Perform some checks before blocking the status of the ticket:
+	//   is the current user an approver of the ticket status?
 	//   has the current user already blocked the ticket?
 
 	currentUserIdentity, err := env.backend.GetUserIdentity()
-
-	nextStates, err := b.Snapshot().NextStates()
 	if err != nil {
 		return err
 	}
 
-	for _, s := range nextStates {
-		currentUserState := b.Snapshot().GetCcbState(currentUserIdentity.Id(), s)
+	currentUserState := b.Snapshot().GetCcbState(currentUserIdentity.Id(), status)
 
-		if currentUserState == bug.RemovedCcbState {
-			return fmt.Errorf("you are not in the ticket %s CCB group", s)
-		}
-		if currentUserState == bug.BlockedCcbState {
-			fmt.Println("you have already blocked this ticket")
-			return nil
-		}
+	if currentUserState == bug.RemovedCcbState {
+		return fmt.Errorf("you are not an approver of the ticket status %s", status)
+	}
+	if currentUserState == bug.BlockedCcbState {
+		fmt.Printf("you have already blocked this ticket status %s\n", status)
+		return nil
+	}
 
-		// Everything looks ok, block
+	// Everything looks ok, block
 
-		_, err = b.CcbBlock(s)
-		if err != nil {
-			return err
-		}
+	_, err = b.CcbBlock(status)
+	if err != nil {
+		return err
 	}
 
 	fmt.Printf("Blocking ticket %s\n", b.Id().Human())

--- a/commands/ccb_rm.go
+++ b/commands/ccb_rm.go
@@ -16,7 +16,7 @@ func newCcbRmCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:      "rm <user> <status> [<id>]",
-		Short:    "Remove a CCB member from a ticket status.",
+		Short:    "Remove a CCB member as an approver of a ticket status.",
 		PreRunE:  loadBackendEnsureUser(env),
 		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -46,9 +46,9 @@ func runCcbRm(env *Env, args []string) error {
 		return err
 	}
 
-	// Perform some checks before removing the user from the CCB of the ticket:
+	// Perform some checks before removing the user as an approver the ticket status:
 	//   is the current user a CCB member?
-	//   is the user to remove in the CCB group of the ticket status?
+	//   is the user to remove an approver of the ticket status?
 
 	currentUserIdentity, err := env.backend.GetUserIdentity()
 
@@ -90,7 +90,7 @@ func runCcbRm(env *Env, args []string) error {
 	}
 
 	if b.Snapshot().GetCcbState(userToRemoveId, status) == bug.RemovedCcbState {
-		fmt.Printf("%s is not in the ticket CCB group\n", userToRemoveIdentity.DisplayName())
+		fmt.Printf("%s is not an approver of the ticket status %s\n", userToRemoveIdentity.DisplayName(), status)
 		return nil
 	}
 
@@ -101,7 +101,7 @@ func runCcbRm(env *Env, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Removing %s from %s CCB group of ticket %s\n", userToRemoveIdentity.DisplayName(), status, b.Id().Human())
+	fmt.Printf("Removing %s as an approver of the ticket %s status %s\n", userToRemoveIdentity.DisplayName(), b.Id().Human(), status)
 
 	return b.Commit()
 }

--- a/commands/ccb_rm.go
+++ b/commands/ccb_rm.go
@@ -15,8 +15,8 @@ func newCcbRmCommand() *cobra.Command {
 	env := newEnv()
 
 	cmd := &cobra.Command{
-		Use:      "rm <user> [<id>]",
-		Short:    "Remove the CCB member from a ticket.",
+		Use:      "rm <user> <status> [<id>]",
+		Short:    "Remove a CCB member from a ticket status.",
 		PreRunE:  loadBackendEnsureUser(env),
 		PostRunE: closeBackend(env),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -28,12 +28,18 @@ func newCcbRmCommand() *cobra.Command {
 }
 
 func runCcbRm(env *Env, args []string) error {
-	if len(args) < 1 {
-		return errors.New("no user supplied")
+	if len(args) < 2 {
+		return errors.New("no user and/or status supplied")
 	}
 
 	userToRemoveString := args[0]
-	args = args[1:]
+
+	status, err := bug.StatusFromString(args[1])
+	if err != nil {
+		return err
+	}
+
+	args = args[2:]
 
 	b, args, err := _select.ResolveBug(env.backend, args)
 	if err != nil {
@@ -42,7 +48,7 @@ func runCcbRm(env *Env, args []string) error {
 
 	// Perform some checks before removing the user from the CCB of the ticket:
 	//   is the current user a CCB member?
-	//   is the user to remove in the CCB group of the ticket?
+	//   is the user to remove in the CCB group of the ticket status?
 
 	currentUserIdentity, err := env.backend.GetUserIdentity()
 
@@ -83,19 +89,19 @@ func runCcbRm(env *Env, args []string) error {
 		return err
 	}
 
-	if b.Snapshot().GetCcbState(userToRemoveId) == bug.RemovedCcbState {
+	if b.Snapshot().GetCcbState(userToRemoveId, status) == bug.RemovedCcbState {
 		fmt.Printf("%s is not in the ticket CCB group\n", userToRemoveIdentity.DisplayName())
 		return nil
 	}
 
 	// Everything looks ok, remove the user
 
-	_, err = b.CcbRm(userToRemoveIdentity)
+	_, err = b.CcbRm(userToRemoveIdentity, status)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Removing %s from CCB group of ticket %s\n", userToRemoveIdentity.DisplayName(), b.Id().Human())
+	fmt.Printf("Removing %s from %s CCB group of ticket %s\n", userToRemoveIdentity.DisplayName(), status, b.Id().Human())
 
 	return b.Commit()
 }

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -109,7 +109,7 @@ func (sb *showBug) layout(g *gocui.Gui) error {
 
 	currentBugHelp := showBugHelp
 
-	validStates, err := sb.bug.Snapshot().NextStates()
+	validStates, err := sb.bug.Snapshot().NextStatuses()
 	for _, vs := range validStates {
 		currentBugHelp = append(currentBugHelp,
 			struct {


### PR DESCRIPTION
through using the ccb function it became clear we needed more precise control, i.e. the ability to have multiple ccb's on a ticket. this PR modifies the ccb commands so that members must be added to a ticket with relation to a certain status, when it's approved it's only for the "next" status. typical workflow will be:

1) ticket created (in "proposed" state), ccb members added to "vetted" and "accepted" statuses
2) ccb members approve ticket, ticket moved to "vetted"
3) ticket goes through other statuses during the change process, ending up in "reviewed"
3) ccb members approve ticket, ticket moved to "accepted"
5) changes merged and ticket moved to "merged"