### PR TITLE
Add external option to validate. Add rebuild-cache global option

### DIFF
--- a/cache/multi_repo_cache.go
+++ b/cache/multi_repo_cache.go
@@ -21,7 +21,7 @@ func NewMultiRepoCache() *MultiRepoCache {
 
 // RegisterRepository register a named repository. Use this for multi-repo setup
 func (c *MultiRepoCache) RegisterRepository(ref string, repo repository.ClockedRepo) (*RepoCache, error) {
-	r, err := NewRepoCache(repo)
+	r, err := NewRepoCache(repo, false)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (c *MultiRepoCache) RegisterRepository(ref string, repo repository.ClockedR
 
 // RegisterDefaultRepository register a unnamed repository. Use this for mono-repo setup
 func (c *MultiRepoCache) RegisterDefaultRepository(repo repository.ClockedRepo) (*RepoCache, error) {
-	r, err := NewRepoCache(repo)
+	r, err := NewRepoCache(repo, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -101,7 +101,7 @@ func NewNamedRepoCache(r repository.ClockedRepo, rebuild bool, name string) (*Re
 		return &RepoCache{}, err
 	}
 
-	if rebuild == false {
+	if !rebuild {
 		err = c.load()
 		if err == nil {
 			return c, nil

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -81,11 +81,11 @@ type RepoCache struct {
 	commits  map[repository.Hash]*object.Commit
 }
 
-func NewRepoCache(r repository.ClockedRepo, forceBuild bool) (*RepoCache, error) {
-	return NewNamedRepoCache(r, forceBuild, "")
+func NewRepoCache(r repository.ClockedRepo, rebuild bool) (*RepoCache, error) {
+	return NewNamedRepoCache(r, rebuild, "")
 }
 
-func NewNamedRepoCache(r repository.ClockedRepo, forceBuild bool, name string) (*RepoCache, error) {
+func NewNamedRepoCache(r repository.ClockedRepo, rebuild bool, name string) (*RepoCache, error) {
 	c := &RepoCache{
 		repo:          r,
 		name:          name,
@@ -101,7 +101,7 @@ func NewNamedRepoCache(r repository.ClockedRepo, forceBuild bool, name string) (
 		return &RepoCache{}, err
 	}
 
-	if forceBuild == false {
+	if rebuild == false {
 		err = c.load()
 		if err == nil {
 			return c, nil

--- a/cache/repo_cache.go
+++ b/cache/repo_cache.go
@@ -81,11 +81,11 @@ type RepoCache struct {
 	commits  map[repository.Hash]*object.Commit
 }
 
-func NewRepoCache(r repository.ClockedRepo) (*RepoCache, error) {
-	return NewNamedRepoCache(r, "")
+func NewRepoCache(r repository.ClockedRepo, forceBuild bool) (*RepoCache, error) {
+	return NewNamedRepoCache(r, forceBuild, "")
 }
 
-func NewNamedRepoCache(r repository.ClockedRepo, name string) (*RepoCache, error) {
+func NewNamedRepoCache(r repository.ClockedRepo, forceBuild bool, name string) (*RepoCache, error) {
 	c := &RepoCache{
 		repo:          r,
 		name:          name,
@@ -101,9 +101,11 @@ func NewNamedRepoCache(r repository.ClockedRepo, name string) (*RepoCache, error
 		return &RepoCache{}, err
 	}
 
-	err = c.load()
-	if err == nil {
-		return c, nil
+	if forceBuild == false {
+		err = c.load()
+		if err == nil {
+			return c, nil
+		}
 	}
 
 	// Cache is either missing, broken or outdated. Rebuilding.

--- a/cache/repo_cache_test.go
+++ b/cache/repo_cache_test.go
@@ -17,7 +17,7 @@ func TestCache(t *testing.T) {
 
 	repository.SetupSigningKey(t, repo, "a@e.org")
 
-	cache, err := NewRepoCache(repo)
+	cache, err := NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	// Create, set and get user identity
@@ -109,7 +109,7 @@ func TestCache(t *testing.T) {
 	require.Empty(t, cache.identitiesExcerpts)
 
 	// Reload, only excerpt are loaded
-	cache, err = NewRepoCache(repo)
+	cache, err = NewRepoCache(repo, false)
 	require.NoError(t, err)
 	require.Empty(t, cache.bugs)
 	require.Empty(t, cache.identities)
@@ -139,10 +139,10 @@ func TestPushPull(t *testing.T) {
 	repository.SetupSigningKey(t, repoA, "a@e.org")
 	repository.SetupSigningKey(t, repoB, "a@e.org")
 
-	cacheA, err := NewRepoCache(repoA)
+	cacheA, err := NewRepoCache(repoA, false)
 	require.NoError(t, err)
 
-	cacheB, err := NewRepoCache(repoB)
+	cacheB, err := NewRepoCache(repoB, false)
 	require.NoError(t, err)
 
 	// Create, set and get user identity
@@ -243,7 +243,7 @@ func TestRemove(t *testing.T) {
 	err = repo.AddRemote("remoteB", "file://"+remoteB.GetPath())
 	require.NoError(t, err)
 
-	repoCache, err := NewRepoCache(repo)
+	repoCache, err := NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	rene, err := repoCache.NewIdentity("René Descartes", "rene@descartes.fr")
@@ -283,7 +283,7 @@ func TestRemove(t *testing.T) {
 func TestCacheEviction(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	repository.SetupSigningKey(t, repo, "a@e.org")
-	repoCache, err := NewRepoCache(repo)
+	repoCache, err := NewRepoCache(repo, false)
 	require.NoError(t, err)
 	repoCache.setCacheSize(2)
 

--- a/commands/env.go
+++ b/commands/env.go
@@ -95,7 +95,7 @@ func loadBackend(env *Env) func(*cobra.Command, []string) error {
 			return err
 		}
 
-		env.backend, err = cache.NewRepoCache(env.repo)
+		env.backend, err = cache.NewRepoCache(env.repo, RebuildCache)
 		if err != nil {
 			return err
 		}

--- a/commands/root.go
+++ b/commands/root.go
@@ -15,6 +15,9 @@ var GitCommit string
 var GitLastTag string
 var GitExactTag string
 
+// Global flags
+var RebuildCache bool
+
 func NewRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   rootCommandName,
@@ -59,6 +62,8 @@ _git_bug() {
 }
 `,
 	}
+
+	cmd.PersistentFlags().BoolVarP(&RebuildCache, "rebuild-cache", "", false, "force the cache to be rebuilt")
 
 	cmd.AddCommand(newAddCommand())
 	cmd.AddCommand(newAssignCommand())

--- a/commands/select/select_test.go
+++ b/commands/select/select_test.go
@@ -16,7 +16,7 @@ func TestSelect(t *testing.T) {
 
 	repository.SetupSigningKey(t, repo, "a@e.org")
 
-	repoCache, err := cache.NewRepoCache(repo)
+	repoCache, err := cache.NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	_, _, err = ResolveBug(repoCache, []string{})

--- a/repository/git.go
+++ b/repository/git.go
@@ -101,7 +101,7 @@ func NewGitRepo(path string, clockLoaders []ClockLoader) (*GitRepo, error) {
 	}
 
 	// Check the repo and retrieve the root path
-	stdout, err := repo.runGitCommand("rev-parse", "--git-dir")
+	stdout, err := repo.runGitCommand("rev-parse", "--absolute-git-dir")
 
 	// Now dir is fetched with "git rev-parse --git-dir". May be it can
 	// still return nothing in some cases. Then empty stdout check is
@@ -141,7 +141,7 @@ func NewGitRepoNoInit(path string) (*GitRepo, error) {
 	}
 
 	// Check the repo and retrieve the root path
-	stdout, err := repo.runGitCommand("rev-parse", "--git-dir")
+	stdout, err := repo.runGitCommand("rev-parse", "--absolute-git-dir")
 
 	// Now dir is fetched with "git rev-parse --git-dir". May be it can
 	// still return nothing in some cases. Then empty stdout check is
@@ -153,7 +153,7 @@ func NewGitRepoNoInit(path string) (*GitRepo, error) {
 	// Fix the path to be sure we are at the root
 	repo.path = stdout
 
-	return repo, nil
+	return setupGitRepo(repo)
 }
 
 // InitGitRepo create a new empty git repo at the given path

--- a/validate/validator.go
+++ b/validate/validator.go
@@ -291,7 +291,7 @@ func (v *Validator) ValidateCommit(ref string) (*packet.PublicKey, error) {
 	return signingKey, nil
 }
 
-// ValidateExternalCommit checks the commit (located in an another repository) signature along with the key's expire time.
+// ValidateExternalCommit checks the commit (located in another repository) signature along with the key's expire time.
 // Returns the pubkey used to sign the specified commit, or an error.
 func (v *Validator) ValidateExternalCommit(repoPath string, ref string) (*packet.PublicKey, error) {
 	repo, err := repository.NewGitRepoNoInit(repoPath)

--- a/validate/validator.go
+++ b/validate/validator.go
@@ -263,7 +263,11 @@ func (v *Validator) checkCommitForKey(hash repository.Hash) error {
 
 // ValidateCommit checks the commit signature along with the key's expire time.
 // Returns the pubkey used to sign the specified commit, or an error.
-func (v *Validator) ValidateCommit(hash repository.Hash) (*packet.PublicKey, error) {
+func (v *Validator) ValidateCommit(ref string) (*packet.PublicKey, error) {
+	hash, err := v.backend.ResolveRef(ref)
+	if err != nil {
+		return nil, err
+	}
 	commit, err := v.backend.ResolveCommit(hash)
 	if err != nil {
 		return nil, err
@@ -277,6 +281,32 @@ func (v *Validator) ValidateCommit(hash repository.Hash) (*packet.PublicKey, err
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	signingKey, err := v.verifyCommitSignature(commit)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid signature")
+	}
+
+	return signingKey, nil
+}
+
+// ValidateExternalCommit checks the commit (located in an another repository) signature along with the key's expire time.
+// Returns the pubkey used to sign the specified commit, or an error.
+func (v *Validator) ValidateExternalCommit(repoPath string, ref string) (*packet.PublicKey, error) {
+	repo, err := repository.NewGitRepoNoInit(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	hash, err := repo.ResolveRevision(plumbing.Revision(ref))
+	if err != nil {
+		return nil, err
+	}
+
+	commit, err := repo.CommitObject(plumbing.NewHash(hash.String()))
+	if err != nil {
+		return nil, err
 	}
 
 	signingKey, err := v.verifyCommitSignature(commit)

--- a/validate/validator_test.go
+++ b/validate/validator_test.go
@@ -64,7 +64,7 @@ func TestNewValidator_EmptyRepo(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(repo)
 
-	backend, err := cache.NewRepoCache(repo)
+	backend, err := cache.NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	checkValidator(t, repo, backend, "", "")
@@ -77,7 +77,7 @@ func TestNewValidator_OneIdentity(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(repo)
 
-	backend, err := cache.NewRepoCache(repo)
+	backend, err := cache.NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	armoredPubkey := repository.SetupSigningKey(t, repo, "a@e.org")
@@ -90,7 +90,7 @@ func TestNewValidator_TwoSeparateIdentities(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(repo)
 
-	backend, err := cache.NewRepoCache(repo)
+	backend, err := cache.NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	armoredPubkey := repository.SetupSigningKey(t, repo, "a@e.org")
@@ -108,7 +108,7 @@ func TestNewValidator_IdentityWithSameKeyTwice(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(repo)
 
-	backend, err := cache.NewRepoCache(repo)
+	backend, err := cache.NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	armoredPubkey := repository.SetupSigningKey(t, repo, "a@e.org")
@@ -125,7 +125,7 @@ func TestNewValidator_TwoIdentitiesWithSameKey(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(repo)
 
-	backend, err := cache.NewRepoCache(repo)
+	backend, err := cache.NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	armoredPubkey := repository.SetupSigningKey(t, repo, "a@e.org")
@@ -147,7 +147,7 @@ func TestNewValidator_TwoIdentitiesTwoVersions(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(repo)
 
-	backend, err := cache.NewRepoCache(repo)
+	backend, err := cache.NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	armoredPubkey := repository.SetupSigningKey(t, repo, "a@e.org")
@@ -170,7 +170,7 @@ func TestNewValidator_WrongEmail(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(repo)
 
-	backend, err := cache.NewRepoCache(repo)
+	backend, err := cache.NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	armoredPubkey := repository.SetupSigningKey(t, repo, "a@e.org")
@@ -186,7 +186,7 @@ func TestNewValidator_RemovedKey(t *testing.T) {
 	repo := repository.CreateTestRepo(false)
 	defer repository.CleanupTestRepos(repo)
 
-	backend, err := cache.NewRepoCache(repo)
+	backend, err := cache.NewRepoCache(repo, false)
 	require.NoError(t, err)
 
 	armoredPubkey := repository.SetupSigningKey(t, repo, "a@e.org")


### PR DESCRIPTION
Two changes added to support use of git ticket on server side hooks:
- An "external" option to validate so that the commit to be validated can be in a different repository. Causes the new function validate/validator.go::ValidateExternalCommit to be called.
- A "rebuild-cache" global option which causes the cache load in repo_cache.go::NewNamedRepoCache to be skipped.

This change also uncovered a couple of bugs in git.go which prevented git repos which are not at the current working directory to be used.