### PR TITLE
Various updates to output formatting of show command

### DIFF
--- a/bug/ccb.go
+++ b/bug/ccb.go
@@ -9,6 +9,7 @@ import (
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/identity"
 	"github.com/daedaleanai/git-ticket/repository"
+	"github.com/daedaleanai/git-ticket/util/colors"
 	"github.com/pkg/errors"
 )
 
@@ -31,6 +32,13 @@ type CcbInfo struct {
 	State  CcbState           // The state of the approval
 }
 
+// CcbInfoByStatus provides functions to fulfill the sort interface
+type CcbInfoByStatus []CcbInfo
+
+func (a CcbInfoByStatus) Len() int           { return len(a) }
+func (a CcbInfoByStatus) Less(i, j int) bool { return a[i].Status < a[j].Status }
+func (a CcbInfoByStatus) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
 // Stringify function for CcbState
 func (s CcbState) String() string {
 	switch s {
@@ -40,6 +48,22 @@ func (s CcbState) String() string {
 		return "Approved"
 	case BlockedCcbState:
 		return "Blocked"
+	case RemovedCcbState:
+		return "Removed"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Colored strings function for CcbState
+func (s CcbState) ColorString() string {
+	switch s {
+	case AddedCcbState:
+		return colors.Blue("Added")
+	case ApprovedCcbState:
+		return colors.Green("Approved")
+	case BlockedCcbState:
+		return colors.Red("Blocked")
 	case RemovedCcbState:
 		return "Removed"
 	default:

--- a/bug/op_add_comment.go
+++ b/bug/op_add_comment.go
@@ -3,7 +3,8 @@ package bug
 import (
 	"encoding/json"
 	"fmt"
-	"time"
+
+	termtext "github.com/MichaelMure/go-term-text"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/identity"
@@ -116,10 +117,10 @@ type AddCommentTimelineItem struct {
 }
 
 func (a AddCommentTimelineItem) String() string {
-	return fmt.Sprintf("(%s) %-20s: commented \"%s\"",
-		a.CreatedAt.Time().Format(time.RFC822),
-		a.Author.DisplayName(),
-		a.Message)
+	return fmt.Sprintf("(%s) %s: commented \"%s\"",
+		a.CreatedAt.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(a.Author.DisplayName(), 15, 0),
+		termtext.LeftPadMaxLine(a.Message, 50, 0))
 }
 
 // Sign post method for gqlgen

--- a/bug/op_create.go
+++ b/bug/op_create.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
+
+	termtext "github.com/MichaelMure/go-term-text"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/identity"
@@ -135,9 +136,9 @@ type CreateTimelineItem struct {
 }
 
 func (c CreateTimelineItem) String() string {
-	return fmt.Sprintf("(%s) %-20s: created ticket",
-		c.CreatedAt.Time().Format(time.RFC822),
-		c.Author.DisplayName())
+	return fmt.Sprintf("(%s) %s: created ticket",
+		c.CreatedAt.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(c.Author.DisplayName(), 15, 0))
 }
 
 // Sign post method for gqlgen

--- a/bug/op_label_change.go
+++ b/bug/op_label_change.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
+	termtext "github.com/MichaelMure/go-term-text"
 	"github.com/pkg/errors"
 
 	"github.com/daedaleanai/git-ticket/entity"
@@ -171,9 +171,9 @@ func (l LabelChangeTimelineItem) String() string {
 			output.WriteString("\"" + string(label) + "\" ")
 		}
 	}
-	return fmt.Sprintf("(%s) %-20s: %s",
-		l.UnixTime.Time().Format(time.RFC822),
-		l.Author.DisplayName(),
+	return fmt.Sprintf("(%s) %s: %s",
+		l.UnixTime.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(l.Author.DisplayName(), 15, 0),
 		output.String())
 }
 

--- a/bug/op_set_assignee.go
+++ b/bug/op_set_assignee.go
@@ -3,7 +3,8 @@ package bug
 import (
 	"encoding/json"
 	"fmt"
-	"time"
+
+	termtext "github.com/MichaelMure/go-term-text"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/identity"
@@ -108,9 +109,9 @@ func (s SetAssigneeTimelineItem) When() timestamp.Timestamp {
 }
 
 func (s SetAssigneeTimelineItem) String() string {
-	return fmt.Sprintf("(%s) %-20s: set assignee \"%s\"",
-		s.UnixTime.Time().Format(time.RFC822),
-		s.Author.DisplayName(),
+	return fmt.Sprintf("(%s) %s: set assignee \"%s\"",
+		s.UnixTime.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(s.Author.DisplayName(), 15, 0),
 		s.Assignee.DisplayName())
 }
 

--- a/bug/op_set_ccb.go
+++ b/bug/op_set_ccb.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
+
+	termtext "github.com/MichaelMure/go-term-text"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/identity"
@@ -168,9 +169,9 @@ func (s SetCcbTimelineItem) String() string {
 	case BlockedCcbState:
 		output.WriteString("blocked ticket status " + s.Ccb.Status.String())
 	}
-	return fmt.Sprintf("(%s) %-20s: %s",
-		s.UnixTime.Time().Format(time.RFC822),
-		s.Author.DisplayName(),
+	return fmt.Sprintf("(%s) %s: %s",
+		s.UnixTime.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(s.Author.DisplayName(), 15, 0),
 		output.String())
 }
 

--- a/bug/op_set_checklist.go
+++ b/bug/op_set_checklist.go
@@ -3,7 +3,8 @@ package bug
 import (
 	"encoding/json"
 	"fmt"
-	"time"
+
+	termtext "github.com/MichaelMure/go-term-text"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/identity"
@@ -116,9 +117,9 @@ func (s SetChecklistTimelineItem) When() timestamp.Timestamp {
 }
 
 func (s SetChecklistTimelineItem) String() string {
-	return fmt.Sprintf("(%s) %-20s: edited \"%s\"",
-		s.UnixTime.Time().Format(time.RFC822),
-		s.Author.DisplayName(),
+	return fmt.Sprintf("(%s) %s: edited \"%s\"",
+		s.UnixTime.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(s.Author.DisplayName(), 15, 0),
 		s.Checklist.Title)
 }
 

--- a/bug/op_set_review.go
+++ b/bug/op_set_review.go
@@ -6,7 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
+
+	termtext "github.com/MichaelMure/go-term-text"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/identity"
@@ -185,9 +186,9 @@ func (s SetReviewTimelineItem) String() string {
 		output.WriteString("[1 comment] ")
 	}
 
-	return fmt.Sprintf("(%s) %-20s: updated revision %s %s",
-		s.UnixTime.Time().Format(time.RFC822),
-		s.Author.DisplayName(),
+	return fmt.Sprintf("(%s) %s: updated revision %s %s",
+		s.UnixTime.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(s.Author.DisplayName(), 15, 0),
 		s.Review.RevisionId,
 		output.String())
 }

--- a/bug/op_set_status.go
+++ b/bug/op_set_status.go
@@ -3,8 +3,8 @@ package bug
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
+	termtext "github.com/MichaelMure/go-term-text"
 	"github.com/pkg/errors"
 
 	"github.com/daedaleanai/git-ticket/entity"
@@ -108,9 +108,9 @@ func (s SetStatusTimelineItem) When() timestamp.Timestamp {
 }
 
 func (s SetStatusTimelineItem) String() string {
-	return fmt.Sprintf("(%s) %-20s: %s",
-		s.UnixTime.Time().Format(time.RFC822),
-		s.Author.DisplayName(),
+	return fmt.Sprintf("(%s) %s: %s",
+		s.UnixTime.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(s.Author.DisplayName(), 15, 0),
 		s.Status.Action())
 }
 

--- a/bug/op_set_title.go
+++ b/bug/op_set_title.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
+
+	termtext "github.com/MichaelMure/go-term-text"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/identity"
@@ -133,9 +134,9 @@ func (s SetTitleTimelineItem) When() timestamp.Timestamp {
 }
 
 func (s SetTitleTimelineItem) String() string {
-	return fmt.Sprintf("(%s) %-20s: set title %s",
-		s.UnixTime.Time().Format(time.RFC822),
-		s.Author.DisplayName(),
+	return fmt.Sprintf("(%s) %s: set title %s",
+		s.UnixTime.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(s.Author.DisplayName(), 15, 0),
 		s.Title)
 }
 

--- a/bug/reviews.go
+++ b/bug/reviews.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 	"time"
 
+	termtext "github.com/MichaelMure/go-term-text"
 	"github.com/thought-machine/gonduit/requests"
 
 	"github.com/daedaleanai/git-ticket/identity"
 	"github.com/daedaleanai/git-ticket/repository"
+	"github.com/daedaleanai/git-ticket/util/colors"
 )
 
 type TransactionType int
@@ -71,19 +73,12 @@ const RemoveReviewInfo = "-1"
 // comment the file & line details, on a single line. Comments over 50 characters
 // are truncated.
 func (c PhabTransaction) OneLineComment() string {
-	var output string
-
 	if c.Type != CommentTransaction {
 		return ""
 	}
 
 	// Put the comment on one line and output the first 50 characters
-	oneLineText := strings.ReplaceAll(c.Text, "\n", " ")
-	if len(oneLineText) > 50 {
-		output = fmt.Sprintf("%.47s...", oneLineText)
-	} else {
-		output = fmt.Sprintf("%-50s", oneLineText)
-	}
+	output := termtext.LeftPadMaxLine(strings.ReplaceAll(c.Text, "\n", " "), 50, 0)
 
 	// If it's an inline comment append the file and line number
 	if c.Path != "" {
@@ -129,7 +124,11 @@ func (r ReviewInfo) LatestOverallStatus() string {
 		}
 	}
 
-	return ls.Status
+	if ls.Status == "accepted" {
+		return colors.Green("accepted")
+	} else {
+		return ls.Status
+	}
 }
 
 // LatestUserStatuses returns a map of users and the latest status they set for

--- a/bug/timeline.go
+++ b/bug/timeline.go
@@ -3,7 +3,8 @@ package bug
 import (
 	"fmt"
 	"strings"
-	"time"
+
+	termtext "github.com/MichaelMure/go-term-text"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/identity"
@@ -67,9 +68,9 @@ func (c CommentTimelineItem) When() timestamp.Timestamp {
 }
 
 func (c CommentTimelineItem) String() string {
-	return fmt.Sprintf("(%s) %-20s: %s",
-		c.CreatedAt.Time().Format(time.RFC822),
-		c.Author.DisplayName(),
+	return fmt.Sprintf("(%s) %s: %s",
+		c.CreatedAt.Time().Format("2006-01-02 15:04:05"),
+		termtext.LeftPadMaxLine(c.Author.DisplayName(), 15, 0),
 		c.Message)
 }
 

--- a/commands/comment.go
+++ b/commands/comment.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	text "github.com/MichaelMure/go-term-text"
+	termtext "github.com/MichaelMure/go-term-text"
 	"github.com/spf13/cobra"
 
 	_select "github.com/daedaleanai/git-ticket/commands/select"
@@ -42,7 +42,7 @@ func runComment(env *Env, args []string) error {
 		env.out.Printf("Author: %s\n", colors.Magenta(comment.Author.DisplayName()))
 		env.out.Printf("Id: %s\n", colors.Cyan(comment.Id().Human()))
 		env.out.Printf("Date: %s\n\n", comment.FormatTime())
-		env.out.Println(text.LeftPadLines(comment.Message, 4))
+		env.out.Println(termtext.LeftPadLines(comment.Message, 4))
 	}
 
 	return nil

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	termtext "github.com/MichaelMure/go-term-text"
 	text "github.com/MichaelMure/go-term-text"
 	"github.com/spf13/cobra"
 
@@ -220,10 +221,10 @@ func lsDefaultFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
 		}
 
 		// truncate + pad if needed
-		labelsFmt := text.TruncateMax(labelsTxt.String(), 10)
-		titleFmt := text.LeftPadMaxLine(strings.TrimSpace(b.Title), 50-text.Len(labelsFmt), 0)
-		authorFmt := text.LeftPadMaxLine(authorName, 15, 0)
-		assigneeFmt := text.LeftPadMaxLine(assigneeName, 15, 0)
+		labelsFmt := termtext.TruncateMax(labelsTxt.String(), 10)
+		titleFmt := termtext.LeftPadMaxLine(strings.TrimSpace(b.Title), 50-termtext.Len(labelsFmt), 0)
+		authorFmt := termtext.LeftPadMaxLine(authorName, 15, 0)
+		assigneeFmt := termtext.LeftPadMaxLine(assigneeName, 15, 0)
 
 		comments := fmt.Sprintf("%4d 💬", b.LenComments)
 		if b.LenComments > 9999 {

--- a/commands/user_ls.go
+++ b/commands/user_ls.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -48,6 +49,8 @@ func runUserLs(env *Env, opts userLsOptions) error {
 		users = append(users, user)
 	}
 
+	sort.Sort(byDisplayName(users))
+
 	switch opts.format {
 	case "json":
 		return userLsJsonFormatter(env, users)
@@ -79,3 +82,9 @@ func userLsJsonFormatter(env *Env, users []*cache.IdentityExcerpt) error {
 	env.out.Printf("%s\n", jsonObject)
 	return nil
 }
+
+type byDisplayName []*cache.IdentityExcerpt
+
+func (a byDisplayName) Len() int           { return len(a) }
+func (a byDisplayName) Less(i, j int) bool { return a[i].DisplayName() < a[j].DisplayName() }
+func (a byDisplayName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/termui/bug_table.go
+++ b/termui/bug_table.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	text "github.com/MichaelMure/go-term-text"
+	termtext "github.com/MichaelMure/go-term-text"
 	"github.com/awesome-gocui/gocui"
 	"github.com/dustin/go-humanize"
 
@@ -327,13 +327,13 @@ func (bt *bugTable) render(v *gocui.View, maxX int) {
 
 		lastEditTime := excerpt.EditTime()
 
-		id := text.LeftPadMaxLine(excerpt.Id.Human(), columnWidths["id"], 0)
-		status := text.LeftPadMaxLine(excerpt.Status.String(), columnWidths["status"], 0)
-		labels := text.TruncateMax(labelsTxt.String(), minInt(columnWidths["title"]-2, 10))
-		title := text.LeftPadMaxLine(strings.TrimSpace(excerpt.Title), columnWidths["title"]-text.Len(labels), 0)
-		author := text.LeftPadMaxLine(authorDisplayName, columnWidths["author"], 0)
-		comments := text.LeftPadMaxLine(summaryTxt, columnWidths["comments"], 0)
-		lastEdit := text.LeftPadMaxLine(humanize.Time(lastEditTime), columnWidths["lastEdit"], 1)
+		id := termtext.LeftPadMaxLine(excerpt.Id.Human(), columnWidths["id"], 0)
+		status := termtext.LeftPadMaxLine(excerpt.Status.String(), columnWidths["status"], 0)
+		labels := termtext.TruncateMax(labelsTxt.String(), minInt(columnWidths["title"]-2, 10))
+		title := termtext.LeftPadMaxLine(strings.TrimSpace(excerpt.Title), columnWidths["title"]-termtext.Len(labels), 0)
+		author := termtext.LeftPadMaxLine(authorDisplayName, columnWidths["author"], 0)
+		comments := termtext.LeftPadMaxLine(summaryTxt, columnWidths["comments"], 0)
+		lastEdit := termtext.LeftPadMaxLine(humanize.Time(lastEditTime), columnWidths["lastEdit"], 1)
 
 		_, _ = fmt.Fprintf(v, "%s %s %s%s %s %s %s\n",
 			colors.Cyan(id),
@@ -352,12 +352,12 @@ func (bt *bugTable) render(v *gocui.View, maxX int) {
 func (bt *bugTable) renderHeader(v *gocui.View, maxX int) {
 	columnWidths := bt.getColumnWidths(maxX)
 
-	id := text.LeftPadMaxLine("ID", columnWidths["id"], 0)
-	status := text.LeftPadMaxLine("STATUS", columnWidths["status"], 0)
-	title := text.LeftPadMaxLine("TITLE", columnWidths["title"], 0)
-	author := text.LeftPadMaxLine("AUTHOR", columnWidths["author"], 0)
-	comments := text.LeftPadMaxLine("CMT", columnWidths["comments"], 0)
-	lastEdit := text.LeftPadMaxLine("LAST EDIT", columnWidths["lastEdit"], 1)
+	id := termtext.LeftPadMaxLine("ID", columnWidths["id"], 0)
+	status := termtext.LeftPadMaxLine("STATUS", columnWidths["status"], 0)
+	title := termtext.LeftPadMaxLine("TITLE", columnWidths["title"], 0)
+	author := termtext.LeftPadMaxLine("AUTHOR", columnWidths["author"], 0)
+	comments := termtext.LeftPadMaxLine("CMT", columnWidths["comments"], 0)
+	lastEdit := termtext.LeftPadMaxLine("LAST EDIT", columnWidths["lastEdit"], 1)
 
 	_, _ = fmt.Fprintf(v, "%s %s %s %s %s %s\n", id, status, title, author, comments, lastEdit)
 }

--- a/termui/help_bar.go
+++ b/termui/help_bar.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	text "github.com/MichaelMure/go-term-text"
+	termtext "github.com/MichaelMure/go-term-text"
 
 	"github.com/daedaleanai/git-ticket/util/colors"
 )
@@ -21,7 +21,7 @@ func (hb helpBar) Render(maxX int) string {
 		builder.WriteByte(' ')
 	}
 
-	l := text.Len(builder.String())
+	l := termtext.Len(builder.String())
 	if l < maxX {
 		builder.WriteString(colors.BlueBg(strings.Repeat(" ", maxX-l)))
 	}

--- a/termui/msg_popup.go
+++ b/termui/msg_popup.go
@@ -3,7 +3,7 @@ package termui
 import (
 	"fmt"
 
-	text "github.com/MichaelMure/go-term-text"
+	termtext "github.com/MichaelMure/go-term-text"
 	"github.com/awesome-gocui/gocui"
 )
 
@@ -45,7 +45,7 @@ func (ep *msgPopup) layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 
 	width := minInt(60, maxX)
-	wrapped, lines := text.Wrap(ep.message, width-2)
+	wrapped, lines := termtext.Wrap(ep.message, width-2)
 	height := minInt(lines+1, maxY-3)
 	x0 := (maxX - width) / 2
 	y0 := (maxY - height) / 2

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	text "github.com/MichaelMure/go-term-text"
+	termtext "github.com/MichaelMure/go-term-text"
 	"github.com/awesome-gocui/gocui"
 
 	"github.com/daedaleanai/git-ticket/bug"
@@ -262,7 +262,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 		snap.CreateTime.Format(timeLayout),
 		edited,
 	)
-	bugHeader, lines := text.Wrap(bugHeader, maxX, text.WrapIndent("   "))
+	bugHeader, lines := termtext.Wrap(bugHeader, maxX, termtext.WrapIndent("   "))
 
 	v, err := sb.createOpView(g, showBugHeaderView, x0, y0, maxX+1, lines, false)
 	if err != nil {
@@ -285,9 +285,9 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 			var lines int
 
 			if op.MessageIsEmpty() {
-				content, lines = text.WrapLeftPadded(emptyMessagePlaceholder(), maxX-1, 4)
+				content, lines = termtext.WrapLeftPadded(emptyMessagePlaceholder(), maxX-1, 4)
 			} else {
-				content, lines = text.WrapLeftPadded(op.Message, maxX-1, 4)
+				content, lines = termtext.WrapLeftPadded(op.Message, maxX-1, 4)
 			}
 
 			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
@@ -305,9 +305,9 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 
 			var message string
 			if op.MessageIsEmpty() {
-				message, _ = text.WrapLeftPadded(emptyMessagePlaceholder(), maxX-1, 4)
+				message, _ = termtext.WrapLeftPadded(emptyMessagePlaceholder(), maxX-1, 4)
 			} else {
-				message, _ = text.WrapLeftPadded(op.Message, maxX-1, 4)
+				message, _ = termtext.WrapLeftPadded(op.Message, maxX-1, 4)
 			}
 
 			content := fmt.Sprintf("%s commented on %s%s\n\n%s",
@@ -316,7 +316,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 				edited,
 				message,
 			)
-			content, lines = text.Wrap(content, maxX)
+			content, lines = termtext.Wrap(content, maxX)
 
 			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
@@ -331,7 +331,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 				colors.Bold(op.Title),
 				op.UnixTime.Time().Format(timeLayout),
 			)
-			content, lines := text.Wrap(content, maxX)
+			content, lines := termtext.Wrap(content, maxX)
 
 			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
@@ -346,7 +346,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 				colors.Bold(op.Status.Action()),
 				op.UnixTime.Time().Format(timeLayout),
 			)
-			content, lines := text.Wrap(content, maxX)
+			content, lines := termtext.Wrap(content, maxX)
 
 			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
@@ -393,7 +393,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 				action.String(),
 				op.UnixTime.Time().Format(timeLayout),
 			)
-			content, lines := text.Wrap(content, maxX)
+			content, lines := termtext.Wrap(content, maxX)
 
 			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
@@ -408,7 +408,7 @@ func (sb *showBug) renderMain(g *gocui.Gui, mainView *gocui.View) error {
 				colors.Bold(op.Checklist.Title),
 				op.UnixTime.Time().Format(timeLayout),
 			)
-			content, lines := text.Wrap(content, maxX)
+			content, lines := termtext.Wrap(content, maxX)
 
 			v, err := sb.createOpView(g, viewName, x0, y0, maxX+1, lines, true)
 			if err != nil {
@@ -481,7 +481,7 @@ func (sb *showBug) renderSidebar(g *gocui.Gui, sideView *gocui.View) error {
 	}
 
 	labels := strings.Join(labelStr, "\n")
-	labels, lines := text.WrapLeftPadded(labels, maxX, 2)
+	labels, lines := termtext.WrapLeftPadded(labels, maxX, 2)
 
 	content := fmt.Sprintf("%s\n\n%s", colors.Bold("  Labels"), labels)
 


### PR DESCRIPTION
Various changes to improve readability of the "show" command. Namely:
- Changed dates to Daedalean standard format (yyyy-mm-dd)
- Applied colour to ccb, checklist and review states
- Applied to truncation to timeline output
- Applied sorting to certain parts so the output is consistent

Also sorted the output of "user ls" so it's not random every time you run the command.