### PR TITLE
Change default output for ls command

### DIFF
--- a/bug/status.go
+++ b/bug/status.go
@@ -24,6 +24,13 @@ const FirstStatus = ProposedStatus
 const LastStatus = RejectedStatus
 const NumStatuses = 8
 
+func ActiveStatuses() []Status {
+	return []Status{InProgressStatus, InReviewStatus, ReviewedStatus, AcceptedStatus}
+}
+func AllStatuses() []Status {
+	return []Status{ProposedStatus, VettedStatus, InProgressStatus, InReviewStatus, ReviewedStatus, AcceptedStatus, MergedStatus, DoneStatus, RejectedStatus}
+}
+
 func (s Status) String() string {
 	switch s {
 	case ProposedStatus:

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -33,7 +33,7 @@ func newLsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ls [QUERY]",
 		Short: "List tickets.",
-		Long: `Display a summary of each ticket.
+		Long: `Display a summary of each ticket. By default shows only "active" tickets, i.e. In Progress, In Review, Reviewed and Accepted.
 
 You can pass an additional query to filter and order the list. This query can be expressed either with a simple query language or with flags.`,
 		Example: `List vetted tickets sorted by last edition with a query:
@@ -53,7 +53,7 @@ git ticket ls --status merged --by creation
 	flags.SortFlags = false
 
 	flags.StringSliceVarP(&options.statusQuery, "status", "s", nil,
-		"Filter by status. Valid values are [open,closed]")
+		"Filter by status. Valid values are [proposed,vetted,inprogress,inreview,reviewed,accepted,merged,done,rejected,ALL]")
 	flags.StringSliceVarP(&options.query.Author, "author", "a", nil,
 		"Filter by author")
 	flags.StringSliceVarP(&options.query.Participant, "participant", "p", nil,
@@ -83,17 +83,22 @@ func runLs(env *Env, opts lsOptions, args []string) error {
 	var err error
 
 	if len(args) >= 1 {
+		// construct filter from query language
 		q, err = query.Parse(strings.Join(args, " "))
 
 		if err != nil {
 			return err
 		}
 	} else {
+		// construct filter from flags
 		err = completeQuery(&opts)
 		if err != nil {
 			return err
 		}
 		q = &opts.query
+	}
+	if len(q.Status) == 0 {
+		q.Status = bug.ActiveStatuses()
 	}
 
 	allIds := env.backend.QueryBugs(q)
@@ -337,6 +342,10 @@ func lsOrgmodeFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
 // Finish the command flags transformation into the query.Query
 func completeQuery(opts *lsOptions) error {
 	for _, str := range opts.statusQuery {
+		if str == "ALL" {
+			opts.query.Status = bug.AllStatuses()
+			break
+		}
 		status, err := bug.StatusFromString(str)
 		if err != nil {
 			return err

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -342,7 +342,7 @@ func lsOrgmodeFormatter(env *Env, bugExcerpts []*cache.BugExcerpt) error {
 // Finish the command flags transformation into the query.Query
 func completeQuery(opts *lsOptions) error {
 	for _, str := range opts.statusQuery {
-		if str == "ALL" {
+		if strings.EqualFold(str, "ALL") {
 			opts.query.Status = bug.AllStatuses()
 			break
 		}

--- a/query/parser.go
+++ b/query/parser.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/daedaleanai/git-ticket/bug"
 )
@@ -26,7 +27,7 @@ func Parse(query string) (*Query, error) {
 	for _, t := range tokens {
 		switch t.qualifier {
 		case "status", "state":
-			if t.value == "ALL" {
+			if strings.EqualFold(t.value, "ALL") {
 				q.Status = bug.AllStatuses()
 				continue
 			}

--- a/query/parser.go
+++ b/query/parser.go
@@ -26,6 +26,10 @@ func Parse(query string) (*Query, error) {
 	for _, t := range tokens {
 		switch t.qualifier {
 		case "status", "state":
+			if t.value == "ALL" {
+				q.Status = bug.AllStatuses()
+				continue
+			}
 			status, err := bug.StatusFromString(t.value)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
As the total number of tickets grow, it's rarely useful to view a list of all of them. Arbitrarily decided that viewing a list of tickets currently being worked on (from In Progress to Accepted) would be a better default list from the ls command.