### PR TITLE
Improve readability for checklists

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -270,8 +270,10 @@ func ChecklistEditorInput(repo repository.RepoCommon, checklist bug.Checklist) (
 		template = template + fmt.Sprintf("#\n#### %s ####\n#\n", s.Title)
 		for qn, q := range s.Questions {
 			template = template + fmt.Sprintf("# %d.%d : %s\n", sn+1, qn+1, q.Question)
-			template = template + fmt.Sprintf("%s\n", q.Comment)
-			template = template + fmt.Sprintf("[%s]\n", q.State.ShortString())
+			if len(strings.TrimSpace(q.Comment)) != 0 {
+				template = template + fmt.Sprintf("%s\n", q.Comment)
+			}
+			template = template + fmt.Sprintf("[%s]\n\n", q.State.ShortString())
 		}
 	}
 
@@ -299,6 +301,10 @@ func ChecklistEditorInput(repo repository.RepoCommon, checklist bug.Checklist) (
 
 	for l, line := range lines {
 		if !inComment {
+			if len(strings.TrimSpace(line)) == 0 {
+				continue
+			}
+
 			if questionSearch.MatchString(line) {
 				// check question number and reset comment
 				matches := questionSearch.FindStringSubmatch(line)


### PR DESCRIPTION
Instead of leaving an empty comment line, let's only print it in the template if the line is not empty.

Additionally, when displaying the checklist, leave an empty line between the `[TBD]` and the next question to better group questions with their state.