### PR TITLE
Added refresh command to update the cache; sped up pull command

### DIFF
--- a/bug/bug.go
+++ b/bug/bug.go
@@ -103,8 +103,8 @@ func FindLocalBug(repo repository.ClockedRepo, prefix string) (*Bug, error) {
 	return ReadLocalBug(repo, matching[0])
 }
 
-// PeakLocalBugEditTime will read the latest edit time of a bug without loading it
-func PeakLocalBugEditTime(repo repository.ClockedRepo, id entity.Id) (time.Time, error) {
+// PeekLocalBugEditTime will read the latest edit time of a bug without loading it
+func PeekLocalBugEditTime(repo repository.ClockedRepo, id entity.Id) (time.Time, error) {
 	if err := id.Validate(); err != nil {
 		return time.Time{}, errors.Wrap(err, "invalid ref ")
 	}

--- a/bug/bug_actions.go
+++ b/bug/bug_actions.go
@@ -67,6 +67,9 @@ func MergeAll(repo repository.ClockedRepo, remote string) <-chan entity.MergeRes
 		for _, remoteRef := range remoteRefs {
 			hashes, err := repo.CommitsBetween(bugsRefPattern+path.Base(remoteRef), remoteRef)
 			if err == nil && hashes == nil {
+				// If the command succeeded and there are no commits between the remote and local ref then we're
+				// up to date. Don't bother with the merge, continue to the next bug. If the command failed then
+				// it could be because there is no local ref.
 				continue
 			}
 

--- a/bug/bug_actions.go
+++ b/bug/bug_actions.go
@@ -2,7 +2,7 @@ package bug
 
 import (
 	"fmt"
-	"strings"
+	"path"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/repository"
@@ -65,8 +65,12 @@ func MergeAll(repo repository.ClockedRepo, remote string) <-chan entity.MergeRes
 		}
 
 		for _, remoteRef := range remoteRefs {
-			refSplit := strings.Split(remoteRef, "/")
-			id := entity.Id(refSplit[len(refSplit)-1])
+			hashes, err := repo.CommitsBetween(bugsRefPattern+path.Base(remoteRef), remoteRef)
+			if err == nil && hashes == nil {
+				continue
+			}
+
+			id := entity.Id(path.Base(remoteRef))
 
 			if err := id.Validate(); err != nil {
 				out <- entity.NewMergeInvalidStatus(id, errors.Wrap(err, "invalid ref").Error())

--- a/cache/repo_cache_common.go
+++ b/cache/repo_cache_common.go
@@ -141,7 +141,7 @@ func (c *RepoCache) MergeAll(remote string) <-chan entity.MergeResult {
 	return out
 }
 
-// RefreshResult holds the state of each if that was updated
+// RefreshResult holds the state of a bug that is new or has been updated
 type RefreshResult struct {
 	Id   entity.Id
 	From time.Time
@@ -168,7 +168,7 @@ func (c *RepoCache) RefreshCache() ([]RefreshResult, error) {
 			// local bug not in the cache!
 			updateCache = true
 		} else {
-			localBugEditTime, err := bug.PeakLocalBugEditTime(c.repo, bugId)
+			localBugEditTime, err := bug.PeekLocalBugEditTime(c.repo, bugId)
 			if err != nil {
 				return nil, err
 			}
@@ -198,7 +198,7 @@ func (c *RepoCache) RefreshCache() ([]RefreshResult, error) {
 
 	// Identities. Nothing clever, just load all the identities again into cache.
 	// Note, if at some point this takes too long then the Identity Excerpts need to be
-	// updated to include the last edit time, then we could so something clever like with
+	// updated to include the last edit time, then we could do something clever like with
 	// the bugs.
 	for i := range identity.ReadAllLocalIdentities(c.repo) {
 		if i.Err != nil {

--- a/commands/refresh.go
+++ b/commands/refresh.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newRefreshCommand() *cobra.Command {
+	env := newEnv()
+
+	cmd := &cobra.Command{
+		Use:      "refresh",
+		Short:    "Refresh cache.",
+		Hidden:   true, // not needed client side, so hide from command list.
+		Long:     `Refreshes the local cache by comparing the state of each ticket with the cached version and updating as necessary. Useful to run on a remote after it has been pushed to.`,
+		PreRunE:  loadBackend(env),
+		PostRunE: closeBackend(env),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRefresh(env, args)
+		},
+	}
+
+	return cmd
+}
+
+func runRefresh(env *Env, args []string) error {
+	results, err := env.backend.RefreshCache()
+
+	if err != nil {
+		return err
+	}
+	if results == nil {
+		return nil
+	}
+
+	for _, r := range results {
+		if r.From.IsZero() {
+			env.out.Printf("%s,NEW\n", r.Id)
+		} else {
+			env.out.Printf("%s,UPDATE,%s,%s\n", r.Id, r.From.Format("2006-01-02T15:04:05"), r.To.Format("2006-01-02T15:04:05"))
+		}
+	}
+
+	return nil
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -85,6 +85,7 @@ _git_bug() {
 	cmd.AddCommand(newStatusCommand())
 	cmd.AddCommand(newTermUICommand())
 	cmd.AddCommand(newTitleCommand())
+	cmd.AddCommand(newRefreshCommand())
 	cmd.AddCommand(newUserCommand())
 	cmd.AddCommand(newValidateCommand())
 	cmd.AddCommand(newVersionCommand())

--- a/identity/identity_actions.go
+++ b/identity/identity_actions.go
@@ -61,6 +61,9 @@ func MergeAll(repo repository.ClockedRepo, remote string) <-chan entity.MergeRes
 		for _, remoteRef := range remoteRefs {
 			hashes, err := repo.CommitsBetween(identityRefPattern+path.Base(remoteRef), remoteRef)
 			if err == nil && hashes == nil {
+				// If the command succeeded and there are no commits between the remote and local ref then we're
+				// up to date. Don't bother with the merge, continue to the next identity. If the command failed then
+				// it could be because there is no local ref.
 				continue
 			}
 

--- a/identity/identity_actions.go
+++ b/identity/identity_actions.go
@@ -2,7 +2,7 @@ package identity
 
 import (
 	"fmt"
-	"strings"
+	"path"
 
 	"github.com/daedaleanai/git-ticket/entity"
 	"github.com/daedaleanai/git-ticket/repository"
@@ -59,8 +59,12 @@ func MergeAll(repo repository.ClockedRepo, remote string) <-chan entity.MergeRes
 		}
 
 		for _, remoteRef := range remoteRefs {
-			refSplit := strings.Split(remoteRef, "/")
-			id := entity.Id(refSplit[len(refSplit)-1])
+			hashes, err := repo.CommitsBetween(identityRefPattern+path.Base(remoteRef), remoteRef)
+			if err == nil && hashes == nil {
+				continue
+			}
+
+			id := entity.Id(path.Base(remoteRef))
 
 			if err := id.Validate(); err != nil {
 				out <- entity.NewMergeInvalidStatus(id, errors.Wrap(err, "invalid ref").Error())

--- a/repository/git.go
+++ b/repository/git.go
@@ -414,13 +414,14 @@ func (repo *GitRepo) ListCommits(ref string) ([]Hash, error) {
 
 }
 
-// CommitsBetween will return the commits reachable from 'after' which are not reachable from 'before'
-func (repo *GitRepo) CommitsBetween(beforeRef, afterRef string) ([]Hash, error) {
-	stdout, err := repo.runGitCommand("rev-list", "^"+beforeRef, afterRef)
+// CommitsBetween will return the commits reachable from 'mainRef' which are not reachable from 'excludeRef'
+func (repo *GitRepo) CommitsBetween(excludeRef, mainRef string) ([]Hash, error) {
+	stdout, err := repo.runGitCommand("rev-list", "^"+excludeRef, mainRef)
 	if err != nil {
 		return nil, err
 	}
 	if stdout == "" {
+		// Return a nil slice if no commits are between the two references
 		return nil, nil
 	}
 
@@ -437,7 +438,6 @@ func (repo *GitRepo) CommitsBetween(beforeRef, afterRef string) ([]Hash, error) 
 // LastCommit will return the latest commit hash of a ref
 func (repo *GitRepo) LastCommit(ref string) (Hash, error) {
 	stdout, err := repo.runGitCommand("rev-list", "-1", ref)
-
 	if err != nil {
 		return "", err
 	}

--- a/repository/git.go
+++ b/repository/git.go
@@ -414,6 +414,37 @@ func (repo *GitRepo) ListCommits(ref string) ([]Hash, error) {
 
 }
 
+// CommitsBetween will return the commits reachable from 'after' which are not reachable from 'before'
+func (repo *GitRepo) CommitsBetween(beforeRef, afterRef string) ([]Hash, error) {
+	stdout, err := repo.runGitCommand("rev-list", "^"+beforeRef, afterRef)
+	if err != nil {
+		return nil, err
+	}
+	if stdout == "" {
+		return nil, nil
+	}
+
+	split := strings.Split(stdout, "\n")
+
+	casted := make([]Hash, len(split))
+	for i, line := range split {
+		casted[i] = Hash(line)
+	}
+
+	return casted, nil
+}
+
+// LastCommit will return the latest commit hash of a ref
+func (repo *GitRepo) LastCommit(ref string) (Hash, error) {
+	stdout, err := repo.runGitCommand("rev-list", "-1", ref)
+
+	if err != nil {
+		return "", err
+	}
+
+	return Hash(stdout), nil
+}
+
 // ReadTree will return the list of entries in a Git tree
 func (repo *GitRepo) ReadTree(hash Hash) ([]TreeEntry, error) {
 	stdout, err := repo.runGitCommand("ls-tree", string(hash))

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -196,7 +196,7 @@ func (r *mockRepoForTest) ListCommits(ref string) ([]Hash, error) {
 	return hashes, nil
 }
 
-func (r *mockRepoForTest) CommitsBetween(beforeRef, afterRef string) ([]Hash, error) {
+func (r *mockRepoForTest) CommitsBetween(excludeRef, mainRef string) ([]Hash, error) {
 	panic("implement me")
 }
 

--- a/repository/mock_repo.go
+++ b/repository/mock_repo.go
@@ -196,6 +196,14 @@ func (r *mockRepoForTest) ListCommits(ref string) ([]Hash, error) {
 	return hashes, nil
 }
 
+func (r *mockRepoForTest) CommitsBetween(beforeRef, afterRef string) ([]Hash, error) {
+	panic("implement me")
+}
+
+func (r *mockRepoForTest) LastCommit(ref string) (Hash, error) {
+	panic("implement me")
+}
+
 func (r *mockRepoForTest) ReadTree(hash Hash) ([]TreeEntry, error) {
 	var data string
 

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -104,8 +104,8 @@ type Repo interface {
 	// ListCommits will return the list of tree hashes of a ref, in chronological order
 	ListCommits(ref string) ([]Hash, error)
 
-	// CommitsBetween will return the commits reachable from 'after' which are not reachable from 'before'
-	CommitsBetween(beforeRef, afterRef string) ([]Hash, error)
+	// CommitsBetween will return the commits reachable from 'mainRef' which are not reachable from 'excludeRef'
+	CommitsBetween(excludeRef, mainRef string) ([]Hash, error)
 
 	// LastCommit will return the latest commit hash of a ref
 	LastCommit(ref string) (Hash, error)

--- a/repository/repo.go
+++ b/repository/repo.go
@@ -104,6 +104,12 @@ type Repo interface {
 	// ListCommits will return the list of tree hashes of a ref, in chronological order
 	ListCommits(ref string) ([]Hash, error)
 
+	// CommitsBetween will return the commits reachable from 'after' which are not reachable from 'before'
+	CommitsBetween(beforeRef, afterRef string) ([]Hash, error)
+
+	// LastCommit will return the latest commit hash of a ref
+	LastCommit(ref string) (Hash, error)
+
 	// CommitObject return a Commit with the given hash. If not found
 	// plumbing.ErrObjectNotFound is returned.
 	CommitObject(h plumbing.Hash) (*object.Commit, error)


### PR DESCRIPTION
Added a refresh command that can be used server-side to update the cache (so it doesn't need to be rebuilt from scratch when changes are pushed or landed in other repos). At the same time sped up the Pull command massively by checking the commit history of a bug before bothering to load it.