### PR TITLE
Update ls to allow filter on time and ccb; Update ls & show to output…

### DIFF
--- a/cache/bug_excerpt.go
+++ b/cache/bug_excerpt.go
@@ -33,6 +33,7 @@ type BugExcerpt struct {
 	AssigneeId   entity.Id
 	Actors       []entity.Id
 	Participants []entity.Id
+	Ccb          []CcbInfoExcerpt
 
 	// If author is identity.Bare, LegacyAuthor is set
 	// If author is identity.Identity, AuthorId is set and data is deported
@@ -47,6 +48,12 @@ type BugExcerpt struct {
 type LegacyAuthorExcerpt struct {
 	Name  string
 	Login string
+}
+
+type CcbInfoExcerpt struct {
+	User   entity.Id
+	Status bug.Status
+	State  bug.CcbState
 }
 
 func (l LegacyAuthorExcerpt) DisplayName() string {
@@ -82,6 +89,13 @@ func NewBugExcerpt(b bug.Interface, snap *bug.Snapshot) *BugExcerpt {
 		assigneeId = snap.Assignee.Id()
 	}
 
+	ccb := make([]CcbInfoExcerpt, 0, len(snap.Ccb))
+	for _, approval := range snap.Ccb {
+		ccb = append(ccb, CcbInfoExcerpt{User: approval.User.Id(),
+			Status: approval.Status,
+			State:  approval.State})
+	}
+
 	e := &BugExcerpt{
 		Id:                b.Id(),
 		CreateLamportTime: b.CreateLamportTime(),
@@ -93,6 +107,7 @@ func NewBugExcerpt(b bug.Interface, snap *bug.Snapshot) *BugExcerpt {
 		AssigneeId:        assigneeId,
 		Actors:            actorsIds,
 		Participants:      participantsIds,
+		Ccb:               ccb,
 		Title:             snap.Title,
 		LenComments:       len(snap.Comments),
 		CreateMetadata:    b.FirstOp().AllMetadata(),

--- a/commands/json_common.go
+++ b/commands/json_common.go
@@ -40,6 +40,12 @@ func NewJSONIdentityFromLegacyExcerpt(excerpt *cache.LegacyAuthorExcerpt) JSONId
 	}
 }
 
+type JSONCcbInfo struct {
+	User   JSONIdentity
+	Status string
+	State  string
+}
+
 type JSONTime struct {
 	Timestamp int64        `json:"timestamp"`
 	Time      time.Time    `json:"time"`

--- a/commands/show.go
+++ b/commands/show.go
@@ -355,6 +355,8 @@ type JSONBugSnapshot struct {
 	Labels       []bug.Label    `json:"labels"`
 	Title        string         `json:"title"`
 	Author       JSONIdentity   `json:"author"`
+	Assignee     JSONIdentity   `json:"assignee"`
+	Ccb          []JSONCcbInfo  `json:"ccb"`
 	Actors       []JSONIdentity `json:"actors"`
 	Participants []JSONIdentity `json:"participants"`
 	Comments     []JSONComment  `json:"comments"`
@@ -386,6 +388,7 @@ func showJsonFormatter(env *Env, snapshot *bug.Snapshot) error {
 		Labels:     snapshot.Labels,
 		Title:      snapshot.Title,
 		Author:     NewJSONIdentity(snapshot.Author),
+		Assignee:   NewJSONIdentity(snapshot.Assignee),
 	}
 
 	jsonBug.Actors = make([]JSONIdentity, len(snapshot.Actors))
@@ -396,6 +399,15 @@ func showJsonFormatter(env *Env, snapshot *bug.Snapshot) error {
 	jsonBug.Participants = make([]JSONIdentity, len(snapshot.Participants))
 	for i, element := range snapshot.Participants {
 		jsonBug.Participants[i] = NewJSONIdentity(element)
+	}
+
+	jsonBug.Ccb = make([]JSONCcbInfo, len(snapshot.Ccb))
+	for i, element := range snapshot.Ccb {
+		jsonBug.Ccb[i] = JSONCcbInfo{
+			User:   NewJSONIdentity(element.User),
+			Status: element.Status.String(),
+			State:  element.State.String(),
+		}
 	}
 
 	jsonBug.Comments = make([]JSONComment, len(snapshot.Comments))

--- a/query/parser.go
+++ b/query/parser.go
@@ -1,8 +1,10 @@
 package query
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/daedaleanai/git-ticket/bug"
 )
@@ -38,10 +40,12 @@ func Parse(query string) (*Query, error) {
 			q.Status = append(q.Status, status)
 		case "author":
 			q.Author = append(q.Author, t.value)
-		case "actor":
-			q.Actor = append(q.Actor, t.value)
 		case "assignee":
 			q.Assignee = append(q.Assignee, t.value)
+		case "ccb":
+			q.Ccb = append(q.Ccb, t.value)
+		case "actor":
+			q.Actor = append(q.Actor, t.value)
 		case "participant":
 			q.Participant = append(q.Participant, t.value)
 		case "label":
@@ -55,6 +59,30 @@ func Parse(query string) (*Query, error) {
 			default:
 				return nil, fmt.Errorf("unknown \"no\" filter \"%s\"", t.value)
 			}
+		case "create-before":
+			parsedTime, err := parseTime(t.value)
+			if err != nil {
+				return nil, err
+			}
+			q.CreateBefore = parsedTime
+		case "create-after":
+			parsedTime, err := parseTime(t.value)
+			if err != nil {
+				return nil, err
+			}
+			q.CreateAfter = parsedTime
+		case "edit-before":
+			parsedTime, err := parseTime(t.value)
+			if err != nil {
+				return nil, err
+			}
+			q.EditBefore = parsedTime
+		case "edit-after":
+			parsedTime, err := parseTime(t.value)
+			if err != nil {
+				return nil, err
+			}
+			q.EditAfter = parsedTime
 		case "sort":
 			if sortingDone {
 				return nil, fmt.Errorf("multiple sorting")
@@ -103,4 +131,16 @@ func parseSorting(q *Query, value string) error {
 	}
 
 	return nil
+}
+
+func parseTime(input string) (time.Time, error) {
+	var formats = []string{"2006-01-02T15:04:05", "2006-01-02"}
+
+	for _, format := range formats {
+		t, err := time.ParseInLocation(format, input, time.Local)
+		if err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, errors.New("Unrecognized time format")
 }

--- a/query/query.go
+++ b/query/query.go
@@ -1,6 +1,10 @@
 package query
 
-import "github.com/daedaleanai/git-ticket/bug"
+import (
+	"time"
+
+	"github.com/daedaleanai/git-ticket/bug"
+)
 
 // Query is the intermediary representation of a Bug's query. It is either
 // produced by parsing a query string (ex: "status:open author:rene") or created
@@ -22,14 +26,19 @@ func NewQuery() *Query {
 
 // Filters is a collection of Filter that implement a complex filter
 type Filters struct {
-	Status      []bug.Status
-	Author      []string
-	Actor       []string
-	Assignee    []string
-	Participant []string
-	Label       []string
-	Title       []string
-	NoLabel     bool
+	Status       []bug.Status
+	Author       []string
+	Assignee     []string
+	Ccb          []string
+	Actor        []string
+	Participant  []string
+	Label        []string
+	Title        []string
+	NoLabel      bool
+	CreateBefore time.Time
+	CreateAfter  time.Time
+	EditBefore   time.Time
+	EditAfter    time.Time
 }
 
 type OrderBy int


### PR DESCRIPTION
… assignee and ccb in JSON format

This change introduces two related updates:
1) The JSON output from the ls command is updated to include the assignee and ccb members on a ticket, for consistency the show command was also updated.
2) The ls command is updated to allow the user to filter the output on the ccb members and on the time a ticket was created or last edited, this required adding the ccb members to the bug excerpt in the cache.